### PR TITLE
operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,49 @@
-# NOTE: This makefile is opinionated and it uses "oc" (instead of kubectl) and "podman" (instead of docker)
+SHELL=/bin/bash
 
-clean-plugin:
-	@rm -rf ${ROOTDIR}/plugin/node_modules
-	@rm -rf ${ROOTDIR}/plugin/dist
+# Identifies the current build.
+VERSION ?= v0.0.1-SNAPSHOT
+COMMIT_HASH ?= $(shell git rev-parse HEAD)
 
-build-plugin: clean-plugin
-	cd plugin && yarn install && yarn build
+# Directories based on the root project directory
+ROOTDIR=$(CURDIR)
+PLUGIN_DIR=${ROOTDIR}/plugin
+OPERATOR_DIR=${ROOTDIR}/operator
 
-build-plugin-image:
-	cd plugin && podman build -t quay.io/kiali/servicemesh-plugin:latest .
+# Determine if we should use Docker OR Podman - value must be one of "docker" or "podman"
+DORP ?= podman
 
-build-plugin-push:
-	cd plugin && podman push quay.io/kiali/servicemesh-plugin:latest
+# Find the oc client executable
+OC ?= $(shell which oc 2>/dev/null || echo "MISSING-OC-FROM-PATH")
 
-deploy-plugin:
-	cd plugin && oc apply -f manifest.yaml
+# list for multi-arch image publishing
+TARGET_ARCHS ?= amd64 arm64 s390x ppc64le
 
-enable-plugin:
-	oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["servicemesh"] } }' --type=merge
+# Local arch details needed when downloading tools
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
 
-restart-plugin:
-	oc rollout restart deployments/servicemesh-plugin -n servicemesh-plugin
+include make/Makefile.plugin.mk
+include make/Makefile.operator.mk
+include make/Makefile.cluster.mk
+include make/Makefile.olm.mk
+
+help:
+	@echo
+	@echo "Plugin targets - used to develop and build the plugin"
+	@sed -n 's/^##//p' make/Makefile.plugin.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+	@echo "Operator targets - used to develop and build the operator"
+	@sed -n 's/^##//p' make/Makefile.operator.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+	@echo "Cluster targets - used to manage images on the remote cluster"
+	@sed -n 's/^##//p' make/Makefile.cluster.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+	@echo "OLM targets - used to deploy the operator via OLM"
+	@sed -n 's/^##//p' make/Makefile.olm.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+
+.ensure-oc-exists:
+	@if [ ! -x "${OC}" ]; then echo "Missing 'oc'"; exit 1; fi
+
+.ensure-oc-login: .ensure-oc-exists
+	@if ! ${OC} whoami &> /dev/null; then echo "You are not logged into an OpenShift cluster. Run 'oc login' before continuing."; exit 1; fi

--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -1,0 +1,83 @@
+#
+# Targets for building and pushing images for deployment into a remote OpenShift cluster.
+#
+
+.prepare-ocp-image-registry: .ensure-oc-login
+	@if [ "$(shell ${OC} get config.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec.managementState}')" != "Managed" ]; then echo "Manually patching image registry operator to ensure it is managed"; ${OC} patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"managementState":"Managed"}}'; sleep 3; fi
+	@if [ "$(shell ${OC} get config.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec.defaultRoute}')" != "true" ]; then echo "Manually patching image registry operator to expose the cluster internal image registry"; ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge; sleep 3; routehost="$$(${OC} get image.config.openshift.io/cluster -o custom-columns=EXT:.status.externalRegistryHostnames[0] --no-headers 2>/dev/null)"; while [ "$${routehost}" == "<none>" -o "$${routehost}" == "" ]; do echo "Waiting for image registry route to start..."; sleep 3; routehost="$$(${OC} get image.config.openshift.io/cluster -o custom-columns=EXT:.status.externalRegistryHostnames[0] --no-headers 2>/dev/null)"; done; fi
+
+.prepare-cluster: .prepare-ocp-image-registry
+	@$(eval CLUSTER_REPO_INTERNAL ?= $(shell ${OC} get image.config.openshift.io/cluster -o custom-columns=INT:.status.internalRegistryHostname --no-headers 2>/dev/null))
+	@$(eval CLUSTER_REPO ?= $(shell ${OC} get image.config.openshift.io/cluster -o custom-columns=EXT:.status.externalRegistryHostnames[0] --no-headers 2>/dev/null))
+	@$(eval CLUSTER_OPERATOR_INTERNAL_NAME ?= ${CLUSTER_REPO_INTERNAL}/${OPERATOR_CONTAINER_NAME})
+	@$(eval CLUSTER_OPERATOR_NAME ?= ${CLUSTER_REPO}/${OPERATOR_CONTAINER_NAME})
+	@$(eval CLUSTER_OPERATOR_INTERNAL_TAG ?= ${CLUSTER_OPERATOR_INTERNAL_NAME}:${OPERATOR_CONTAINER_VERSION})
+	@$(eval CLUSTER_OPERATOR_TAG ?= ${CLUSTER_OPERATOR_NAME}:${OPERATOR_CONTAINER_VERSION})
+	@$(eval ALL_IMAGES_NAMESPACE ?= $(shell echo ${CLUSTER_OPERATOR_NAME} | sed -e 's/.*\/\(.*\)\/.*/\1/'))
+	@if [ "${CLUSTER_REPO_INTERNAL}" == "" -o "${CLUSTER_REPO_INTERNAL}" == "<none>" ]; then echo "Cannot determine OCP internal registry hostname. Make sure you 'oc login' to your cluster."; exit 1; fi
+	@if [ "${CLUSTER_REPO}" == "" -o "${CLUSTER_REPO}" == "<none>" ]; then echo "Cannot determine OCP external registry hostname. The OpenShift image registry has not been made available for external client access"; exit 1; fi
+	@echo "OCP repos: external=[${CLUSTER_REPO}] internal=[${CLUSTER_REPO_INTERNAL}]"
+	@${OC} get namespace ${ALL_IMAGES_NAMESPACE} &> /dev/null || \
+	  ${OC} create namespace ${ALL_IMAGES_NAMESPACE} &> /dev/null
+	@${OC} policy add-role-to-group system:image-puller system:serviceaccounts:${OPERATOR_NAMESPACE} --namespace=${ALL_IMAGES_NAMESPACE} &> /dev/null
+	@# we need to make sure the 'default' service account is created - we'll need it later for the pull secret
+	@for i in {1..5}; do ${OC} get sa default -n ${ALL_IMAGES_NAMESPACE} &> /dev/null && break || echo -n "." && sleep 1; done; echo
+
+.prepare-operator-pull-secret: .prepare-cluster
+	@# base64 encode a pull secret (using the 'default' sa secret) that can be used to pull the operator image from the OpenShift internal registry
+	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} -z default --to=- | base64 -w0))
+	@$(eval OPERATOR_IMAGE_PULL_SECRET_NAME ?= ossmplugin-operator-pull-secret)
+
+.create-operator-pull-secret: .prepare-operator-pull-secret
+	@if [ -n "${OPERATOR_IMAGE_PULL_SECRET_JSON}" ] && ! (${OC} get secret ${OPERATOR_IMAGE_PULL_SECRET_NAME} --namespace ${OPERATOR_NAMESPACE} &> /dev/null); then \
+		echo "${OPERATOR_IMAGE_PULL_SECRET_JSON}" | base64 -d > /tmp/ossmplugin-operator-pull-secret.json; \
+		${OC} get namespace ${OPERATOR_NAMESPACE} &> /dev/null || ${OC} create namespace ${OPERATOR_NAMESPACE}; \
+		${OC} create secret generic ${OPERATOR_IMAGE_PULL_SECRET_NAME} --from-file=.dockerconfigjson=/tmp/ossmplugin-operator-pull-secret.json --type=kubernetes.io/dockerconfigjson --namespace=${OPERATOR_NAMESPACE}; \
+		${OC} label secret ${OPERATOR_IMAGE_PULL_SECRET_NAME} --namespace ${OPERATOR_NAMESPACE} app.kubernetes.io/name=ossmplugin-operator; \
+		rm /tmp/ossmplugin-operator-pull-secret.json; \
+	fi
+
+## cluster-status: Outputs details of the client and server for the cluster
+cluster-status: .prepare-cluster
+	@echo "================================================================="
+	@echo "CLUSTER DETAILS"
+	@echo "================================================================="
+	@echo "Client executable: ${OC}"
+	@echo "================================================================="
+	${OC} version
+	@echo "================================================================="
+	@echo "Age of cluster: $(shell ${OC} get namespace kube-system --no-headers | tr -s ' ' | cut -d ' ' -f3)"
+	@echo "================================================================="
+	@echo "Cluster nodes:"
+	@for n in $(shell ${OC} get nodes -o name); do echo "Node=[$${n}]" "CPUs=[$$(${OC} get $${n} -o jsonpath='{.status.capacity.cpu}')] Memory=[$$(${OC} get $${n} -o jsonpath='{.status.capacity.memory}')]"; done
+	@echo "================================================================="
+	@echo "Console URL: $(shell ${OC} get console cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null)"
+	@echo "API Server:  $(shell ${OC} whoami --show-server 2>/dev/null)"
+	@echo "================================================================="
+	@echo "Operator image as seen from inside the cluster:    ${CLUSTER_OPERATOR_INTERNAL_NAME}"
+	@echo "Operator image that will be pushed to the cluster: ${CLUSTER_OPERATOR_TAG}"
+	@echo "================================================================="
+	@echo "oc whoami -c: $(shell ${OC} whoami -c 2>/dev/null)"
+	@echo "================================================================="
+ifeq ($(DORP),docker)
+	@echo "Image Registry login: docker login -u $(shell ${OC} whoami | tr -d ':')" '-p $$(${OC} whoami -t)' "${CLUSTER_REPO}"
+	@echo "================================================================="
+else
+	@echo "Image Registry login: podman login --tls-verify=false -u $(shell ${OC} whoami | tr -d ':')" '-p $$(${OC} whoami -t)' "${CLUSTER_REPO}"
+	@echo "================================================================="
+endif
+
+## cluster-build-operator: Builds the operator image for development with a remote cluster
+cluster-build-operator: .prepare-cluster build-operator
+	@echo Re-tag the already built operator container image
+	${DORP} tag ${OPERATOR_QUAY_TAG} ${CLUSTER_OPERATOR_TAG}
+
+## cluster-push-operator: Builds then pushes the operator container image to a remote cluster
+cluster-push-operator: cluster-build-operator
+ifeq ($(DORP),docker)
+	@echo Pushing operator image to remote cluster using docker: ${CLUSTER_OPERATOR_TAG}
+	docker push ${CLUSTER_OPERATOR_TAG}
+else
+	@echo Pushing operator image to remote cluster using podman: ${CLUSTER_OPERATOR_TAG}
+	podman push --tls-verify=false ${CLUSTER_OPERATOR_TAG}
+endif

--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -1,0 +1,142 @@
+#
+# Targets for deploying the operator via OLM.
+#
+
+# Identifies the bundle and index images that will be built
+OLM_IMAGE_ORG ?= ${OPERATOR_IMAGE_ORG}
+OLM_BUNDLE_NAME ?= ${OLM_IMAGE_ORG}/ossmplugin-operator-bundle
+OLM_INDEX_NAME ?= ${OLM_IMAGE_ORG}/ossmplugin-operator-index
+
+OLM_INDEX_BASE_IMAGE ?= quay.io/openshift/origin-operator-registry:4.10
+
+.download-opm-if-needed:
+	@if [ "$(shell which opm 2>/dev/null || echo -n "")" == "" ]; then \
+	  mkdir -p "${OPERATOR_OUTDIR}/operator-sdk-install" ;\
+	  if [ -x "${OPERATOR_OUTDIR}/operator-sdk-install/opm" ]; then \
+	    echo "You do not have opm installed in your PATH. Will use the one found here: ${OPERATOR_OUTDIR}/operator-sdk-install/opm" ;\
+	  else \
+	    echo "You do not have opm installed in your PATH. The binary will be downloaded to ${OPERATOR_OUTDIR}/operator-sdk-install/opm" ;\
+	    curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.22.1/${OS}-${ARCH}-opm > "${OPERATOR_OUTDIR}/operator-sdk-install/opm" ;\
+	    chmod +x "${OPERATOR_OUTDIR}/operator-sdk-install/opm" ;\
+	  fi ;\
+	fi
+
+.ensure-opm-exists: .download-opm-if-needed
+	@$(eval OPM ?= $(shell which opm 2>/dev/null || echo "${OPERATOR_OUTDIR}/operator-sdk-install/opm"))
+	@"${OPM}" version
+
+## get-opm: Downloads the OPM operator SDK tool if it is not already in PATH.
+get-opm: .ensure-opm-exists
+	@echo OPM location: ${OPM}
+
+## validate-olm-metadata: Checks the latest version of the OLM bundle metadata for correctness.
+validate-olm-metadata: .ensure-operator-sdk-exists
+	@printf "==========\nValidating ossmplugin-ossm metadata\n==========\n"
+	@mkdir -p ${OPERATOR_OUTDIR}/ossmplugin-ossm && rm -rf ${OPERATOR_OUTDIR}/ossmplugin-ossm/* && cp -R ${OPERATOR_DIR}/manifests/ossmplugin-ossm ${OPERATOR_OUTDIR} && cat ${OPERATOR_DIR}/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml | OSSMPLUGIN_OPERATOR_VERSION="2.0.0" OSSMPLUGIN_OLD_OPERATOR_VERSION="1.0.0" OSSMPLUGIN_OPERATOR_TAG=":2.0.0" OSSMPLUGIN_0_1_TAG=":1.0.0" CREATED_AT="2021-01-01T00:00:00Z" envsubst > ${OPERATOR_OUTDIR}/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml && ${OP_SDK} bundle validate --verbose ${OPERATOR_OUTDIR}/ossmplugin-ossm
+	@printf "==========\nValidating the latest version of ossmplugin-community metadata\n==========\n"
+	@for d in $$(ls -1d ${OPERATOR_DIR}/manifests/ossmplugin-community/* | sort -V | grep -v ci.yaml | tail -n 1); do ${OP_SDK} bundle --verbose validate $$d; done
+
+.determine-olm-bundle-version:
+	@$(eval BUNDLE_VERSION ?= $(shell echo -n "${VERSION}" | sed 's/-SNAPSHOT//' ))
+
+## build-olm-bundle: Builds the latest bundle version for deploying the operator in OLM
+build-olm-bundle: .prepare-cluster .determine-olm-bundle-version
+	@echo Will bundle version [${BUNDLE_VERSION}]
+	@mkdir -p ${OPERATOR_OUTDIR}/bundle
+	cp -R ${OPERATOR_DIR}/manifests/template/* ${OPERATOR_OUTDIR}/bundle
+	${OPERATOR_DIR}/manifests/generate-csv.sh -ov "NONE" -nv "${BUNDLE_VERSION}" -opin "${CLUSTER_OPERATOR_INTERNAL_NAME}" -opiv "${OPERATOR_CONTAINER_VERSION}" > ${OPERATOR_OUTDIR}/bundle/manifests/ossmplugin.clusterserviceversion.yaml
+	${DORP} build -f ${OPERATOR_OUTDIR}/bundle/bundle.Dockerfile -t ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
+
+## cluster-push-olm-bundle: Builds then pushes the OLM bundle container image to a remote cluster
+cluster-push-olm-bundle: build-olm-bundle
+ifeq ($(DORP),docker)
+	@echo Pushing olm bundle image to remote cluster using docker: ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
+	docker push ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
+else
+	@echo Pushing olm bundle image to remote cluster using podman: ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
+	podman push --tls-verify=false ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}
+endif
+
+## build-olm-index: Pushes the OLM bundle then generates the OLM index
+# See https://docs.openshift.com/container-platform/4.10/operators/admin/olm-managing-custom-catalogs.html
+build-olm-index: .ensure-opm-exists cluster-push-olm-bundle
+	@rm -rf ${OPERATOR_OUTDIR}/index
+	@mkdir -p ${OPERATOR_OUTDIR}/index/ossmplugin-index
+	${OPM} init ossmplugin --default-channel=stable --output yaml > ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	${OPM} render --skip-tls-verify ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION} --output yaml >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@# We need OLM to pull the index from the internal registry - change the index to only use the internal registry name
+	sed -i 's|${CLUSTER_REPO}|${CLUSTER_REPO_INTERNAL}|g' ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "---"                                               >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "schema: olm.channel"                               >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "package: ossmplugin"                               >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "name: stable"                                      >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "entries:"                                          >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	@echo "- name: ${OPERATOR_IMAGE_NAME}.${BUNDLE_VERSION}"  >> ${OPERATOR_OUTDIR}/index/ossmplugin-index/index.yaml
+	${OPM} validate ${OPERATOR_OUTDIR}/index/ossmplugin-index
+	@# Now generate the Dockerfile
+	@echo "FROM ${OLM_INDEX_BASE_IMAGE}"                                   >  ${OPERATOR_OUTDIR}/index/ossmplugin-index.Dockerfile
+	@echo 'ENTRYPOINT ["/bin/opm"]'                                        >> ${OPERATOR_OUTDIR}/index/ossmplugin-index.Dockerfile
+	@echo 'CMD ["serve", "/configs"]'                                      >> ${OPERATOR_OUTDIR}/index/ossmplugin-index.Dockerfile
+	@echo "ADD ossmplugin-index /configs"                                  >> ${OPERATOR_OUTDIR}/index/ossmplugin-index.Dockerfile
+	@echo "LABEL operators.operatorframework.io.index.configs.v1=/configs" >> ${OPERATOR_OUTDIR}/index/ossmplugin-index.Dockerfile
+	cd ${OPERATOR_OUTDIR}/index && ${DORP} build . -f ossmplugin-index.Dockerfile -t ${CLUSTER_REPO}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}
+
+## cluster-push-olm-index: Pushes the OLM bundle and then builds and pushes the OLM index to the cluster
+cluster-push-olm-index: build-olm-index
+ifeq ($(DORP),docker)
+	@echo Pushing OLM index image to remote cluster using docker: ${CLUSTER_REPO}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}
+	docker push ${CLUSTER_REPO}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}
+else
+	@echo Pushing OLM index image to remote cluster using podman: ${CLUSTER_REPO}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}
+	podman push --tls-verify=false ${CLUSTER_REPO}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}
+endif
+
+.generate-catalog-source: .prepare-cluster .determine-olm-bundle-version .prepare-operator-pull-secret
+	@mkdir -p "${OPERATOR_OUTDIR}"
+	@echo "apiVersion: operators.coreos.com/v1alpha1" >  ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "kind: CatalogSource"                       >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "metadata:"                                 >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  name: ossmplugin-catalog"                >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  namespace: ${OPERATOR_NAMESPACE}"        >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "spec:"                                     >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  displayName: Test OSSM Plugin Operator"  >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  publisher: Local Developer"              >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  secrets:"                                >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  - ${OPERATOR_IMAGE_PULL_SECRET_NAME}"    >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  sourceType: grpc"                        >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+	@echo "  image: ${CLUSTER_REPO_INTERNAL}/${OLM_INDEX_NAME}:${BUNDLE_VERSION}" >> ${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml
+
+## deploy-catalog-source: Creates the OLM CatalogSource on the remote cluster
+deploy-catalog-source: .generate-catalog-source cluster-push-olm-index .create-operator-pull-secret
+	${OC} apply -f "${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml"
+
+## undeploy-catalog-source: Deletes the OLM CatalogSource from the remote cluster
+undeploy-catalog-source: .generate-catalog-source
+	${OC} delete --ignore-not-found=true -f "${OPERATOR_OUTDIR}/ossmplugin-catalogsource.yaml"
+
+.generate-subscription:
+	@mkdir -p "${OPERATOR_OUTDIR}"
+	@echo "apiVersion: operators.coreos.com/v1alpha1" >  ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "kind: Subscription"                        >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "metadata:"                                 >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  name: ossmplugin-subscription"           >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  namespace: ${OPERATOR_NAMESPACE}"        >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "spec:"                                     >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  channel: stable"                         >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  installPlanApproval: Automatic"          >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  name: ossmplugin"                        >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  source: ossmplugin-catalog"              >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  sourceNamespace: ${OPERATOR_NAMESPACE}"  >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "  config:"                                 >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "    env:"                                  >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo "    - name: ALLOW_AD_HOC_OSSMPLUGIN_IMAGE" >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+	@echo '      value: "true"'                       >> ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+
+## deploy-subscription: Creates the OLM Subscription on the remote cluster which installs the operator
+deploy-subscription: .ensure-oc-login .generate-subscription
+	${OC} apply -f ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+
+## undeploy-subscription: Deletes the OLM Subscription from the remote cluster which uninstalls the operator
+undeploy-subscription: .ensure-oc-login .generate-subscription
+	${OC} delete --ignore-not-found=true -f ${OPERATOR_OUTDIR}/ossmplugin-subscription.yaml
+

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -1,0 +1,233 @@
+#
+# Targets for working with the OSSM Plugin Operator.
+#
+
+# Where operator generated or downloaded files will go
+OPERATOR_OUTDIR=${OPERATOR_DIR}/_output
+
+# Identifies the operator container image that will be built
+OPERATOR_IMAGE_ORG ?= kiali
+OPERATOR_IMAGE_NAME ?= ossmplugin-operator
+OPERATOR_CONTAINER_NAME ?= ${OPERATOR_IMAGE_ORG}/${OPERATOR_IMAGE_NAME}
+OPERATOR_CONTAINER_VERSION ?= ${VERSION}
+OPERATOR_QUAY_NAME ?= quay.io/${OPERATOR_CONTAINER_NAME}
+OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
+
+# The version of the SDK this Makefile will download if needed, and the corresponding base image
+OPERATOR_SDK_VERSION ?= 1.18.1
+OPERATOR_BASE_IMAGE_VERSION ?= v${OPERATOR_SDK_VERSION}
+OPERATOR_BASE_IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
+# These are what we really want - but origin-ansible-operator does not support multiarch today.
+# When that is fixed, we want to use this image instead of the image above.
+# See: https://github.com/kiali/kiali/issues/4483
+#OPERATOR_BASE_IMAGE_VERSION ?= 4.11
+#OPERATOR_BASE_IMAGE_REPO ?= quay.io/openshift/origin-ansible-operator
+
+# The OLM Namespace where catalog sources, subscriptions, and operators are deployed
+OPERATOR_NAMESPACE ?= openshift-operators
+
+## clean-operator: Cleans the operator _output/ content.
+clean-operator:
+	@rm -rf "${OPERATOR_OUTDIR}"
+
+.download-operator-sdk-if-needed:
+	@if [ "$(shell which operator-sdk 2>/dev/null || echo -n "")" == "" ]; then \
+	  mkdir -p "${OPERATOR_OUTDIR}/operator-sdk-install" ;\
+	  if [ -x "${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk" ]; then \
+	    echo "You do not have operator-sdk installed in your PATH. Will use the one found here: ${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	  else \
+	    echo "You do not have operator-sdk installed in your PATH. The binary will be downloaded to ${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_${OS}_${ARCH} > "${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	    chmod +x "${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	  fi ;\
+	fi
+
+.ensure-operator-sdk-exists: .download-operator-sdk-if-needed
+	@$(eval OP_SDK ?= $(shell which operator-sdk 2>/dev/null || echo "${OPERATOR_OUTDIR}/operator-sdk-install/operator-sdk"))
+	@"${OP_SDK}" version
+
+## get-operator-sdk: Downloads the Operator SDK CLI if it is not already in PATH.
+get-operator-sdk: .ensure-operator-sdk-exists
+	@echo Operator SDK location: ${OP_SDK}
+
+.download-ansible-operator-if-needed:
+	@if [ "$(shell which ansible-operator 2>/dev/null || echo -n "")" == "" ]; then \
+	  mkdir -p "${OPERATOR_OUTDIR}/ansible-operator-install" ;\
+	  if [ -x "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator" ]; then \
+	    echo "You do not have ansible-operator installed in your PATH. Will use the one found here: ${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator" ;\
+	  else \
+	    echo "You do not have ansible-operator installed in your PATH. The binary will be downloaded to ${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator" ;\
+	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/ansible-operator_${OS}_${ARCH} > "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator" ;\
+	    chmod +x "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator" ;\
+	  fi ;\
+	fi
+
+.ensure-ansible-operator-exists: .download-ansible-operator-if-needed
+	@$(eval ANSIBLE_OPERATOR_BIN ?= $(shell which ansible-operator 2>/dev/null || echo "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-operator"))
+	@"${ANSIBLE_OPERATOR_BIN}" version
+
+.download-ansible-runner-if-needed:
+	@if [ "$(shell which ansible-runner 2>/dev/null || echo -n "")" == "" ]; then \
+	  mkdir -p "${OPERATOR_OUTDIR}/ansible-operator-install" ;\
+	  if [ -x "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-runner" ]; then \
+	    echo "You do not have ansible-runner installed in your PATH.  Will use the one found here: ${OPERATOR_OUTDIR}/ansible-operator-install/ansible-runner" ;\
+	  else \
+	    echo "You do not have ansible-runner installed in your PATH. An attempt to install it will be made and a softlink to its binary placed at ${OPERATOR_OUTDIR}/ansible-operator-install/ansible-runner" ;\
+	    echo "If the installation fails, you must install it manually. See: https://ansible-runner.readthedocs.io/en/latest/install/" ;\
+	    python3 -m pip install ansible-runner ;\
+	    ln --force -s "${HOME}/.local/bin/ansible-runner" "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-runner" ;\
+	  fi ;\
+	fi
+
+.ensure-ansible-runner-exists: .download-ansible-runner-if-needed
+	@$(eval ANSIBLE_RUNNER_BIN ?= $(shell which ansible-runner 2>/dev/null || echo "${OPERATOR_OUTDIR}/ansible-operator-install/ansible-runner"))
+	@"${ANSIBLE_RUNNER_BIN}" --version
+
+## get-ansible-operator: Downloads the Ansible Operator binary if it is not already in PATH.
+get-ansible-operator: .ensure-ansible-operator-exists .ensure-ansible-runner-exists
+	@echo "Ansible Operator location: ${ANSIBLE_OPERATOR_BIN} (ansible-runner: ${ANSIBLE_RUNNER_BIN})"
+
+## create-test-namespace: Creates a namespace where you can install the test CR.
+create-test-namespace: .ensure-oc-login
+	${OC} get namespace ossmplugin &> /dev/null || ${OC} create namespace ossmplugin
+
+## delete-test-namespace: Removes the test namespace if it exists
+delete-test-namespace: .ensure-oc-login
+	${OC} delete --ignore-not-found=true namespace ossmplugin
+
+## install-crd: Installs the OSSM Plugin CRD into the cluster.
+install-crd: .ensure-oc-login
+	${OC} apply -f "${OPERATOR_DIR}/manifests/template/manifests/ossmplugin.crd.yaml"
+
+## uninstall-crd: Removes the OSSM Plugin CRD from the cluster along with all CRs that may exist.
+uninstall-crd: purge-all-crs
+	${OC} delete --ignore-not-found=true -f "${OPERATOR_DIR}/manifests/template/manifests/ossmplugin.crd.yaml"
+
+## install-cr: Installs a test OSSM Plugin CR into the cluster.
+install-cr: create-test-namespace
+	@kiali_route="$$(${OC} get routes -l app.kubernetes.io/name=kiali --all-namespaces -o jsonpath='{.items[0].spec.host}' 2> /dev/null)" ;\
+	if [ -n "$${kiali_route}" ]; then \
+		echo -n "Waiting for the CRD to be established..." ;\
+		while ! ${OC} get crd ossmplugins.kiali.io &> /dev/null ; do echo -n '.'; sleep 1; done ;\
+		${OC} wait --for condition=established --timeout=60s crd ossmplugins.kiali.io ;\
+		cat "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml" | KIALI_URL="https://$${kiali_route}" envsubst | ${OC} apply -f - ;\
+	else \
+		echo "Could not find the Kiali route URL. You need to install Kiali first." && exit 1 ;\
+	fi
+
+## uninstall-cr: Deletes the test OSSM Plugin CR from the cluster and waits for the operator to finalize the deletion.
+uninstall-cr:
+	${OC} delete --ignore-not-found=true -f "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml"
+
+## purge-all-crs: Purges all OSSM Plugin CRs from the cluster, forcing them to delete without the operator finalizing them.
+purge-all-crs: .ensure-oc-login
+	@for k in $(shell ${OC} get ossmplugin --ignore-not-found=true --all-namespaces -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | sed 's/  */:/g') ;\
+	  do \
+	    cr_namespace="$$(echo $${k} | cut -d: -f1)" ;\
+	    cr_name="$$(echo $${k} | cut -d: -f2)" ;\
+	    echo "Deleting Kiali CR [$${cr_name}] in namespace [$${cr_namespace}]" ;\
+	    ${OC} patch  ossmplugin $${cr_name} -n $${cr_namespace} -p '{"metadata":{"finalizers": []}}' --type=merge ;\
+	    ${OC} delete ossmplugin $${cr_name} -n $${cr_namespace} ;\
+	  done
+
+## run-operator: Runs the OSSM Plugin Operator via the ansible-operator.
+run-operator: install-crd install-cr get-ansible-operator
+	cd ${OPERATOR_DIR} && ALLOW_AD_HOC_OSSMPLUGIN_IMAGE=true POD_NAMESPACE="does-not-exist" ANSIBLE_ROLES_PATH="${OPERATOR_DIR}/roles" PATH="${PATH}:${OPERATOR_OUTDIR}/ansible-operator-install" ansible-operator run --zap-log-level=debug
+
+## run-playbook: Run the operator ansible playbooks directly. You must have Ansible installed for this to work.
+run-playbook: install-crd
+	@$(eval ANSIBLE_PYTHON_INTERPRETER ?= $(shell if (which python &> /dev/null && python --version 2>&1 | grep -q " 2\.*"); then echo "-e ansible_python_interpreter=python3"; else echo ""; fi))
+	@if [ ! -z "${ANSIBLE_PYTHON_INTERPRETER}" ]; then echo "ANSIBLE_PYTHON_INTERPRETER is [${ANSIBLE_PYTHON_INTERPRETER}]. Make sure that refers to a Python3 installation. If you do not have Python3 in that location, you must ensure you have Python3 and ANSIBLE_PYTHON_INTERPRETER is set to '-e ansible_python_interpreter=<full path to your python3 executable>"; fi
+	@echo "Create a dummy Kiali CR"; ${OC} apply -f ${OPERATOR_DIR}/dev-playbook-config/dev-ossmplugin-cr.yaml
+	ansible-galaxy collection install operator_sdk.util community.kubernetes
+	ALLOW_AD_HOC_OSSMPLUGIN_IMAGE=true POD_NAMESPACE="does-not-exist" ANSIBLE_ROLES_PATH=${OPERATOR_DIR}/roles ansible-playbook -vvv ${ANSIBLE_PYTHON_INTERPRETER} -i ${OPERATOR_DIR}/dev-playbook-config/dev-hosts.yaml ${OPERATOR_DIR}/dev-playbook-config/dev-playbook.yaml
+	@echo "Remove the dummy Kiali CR"; ${OC} delete -f ${OPERATOR_DIR}/dev-playbook-config/dev-ossmplugin-cr.yaml
+
+## build-operator: Build operator container image.
+build-operator:
+	${DORP} build --pull -t ${OPERATOR_QUAY_TAG} --build-arg OPERATOR_BASE_IMAGE_REPO=${OPERATOR_BASE_IMAGE_REPO} --build-arg OPERATOR_BASE_IMAGE_VERSION=${OPERATOR_BASE_IMAGE_VERSION} -f ${OPERATOR_DIR}/build/Dockerfile ${OPERATOR_DIR}
+
+## push-operator: Pushes the operator image to quay.
+push-operator:
+	${DORP} push ${OPERATOR_QUAY_TAG}
+
+## operator-create: Creates an operator in the remote cluster via OLM
+operator-create: deploy-catalog-source deploy-subscription
+
+## operator-delete: Deletes the operator from the remote cluster via OLM
+operator-delete: uninstall-cr undeploy-subscription undeploy-catalog-source delete-test-namespace uninstall-crd
+	@echo "Deleting OLM CSVs to fully uninstall OSSM Plugin operator and its related resources"
+	@for csv in $$(${OC} get csv --all-namespaces --no-headers -o custom-columns=NS:.metadata.namespace,N:.metadata.name | sed 's/  */:/g' | grep ossmplugin-operator) ;\
+	do \
+		${OC} delete --ignore-not-found=true csv -n $$(echo -n $${csv} | cut -d: -f1) $$(echo -n $${csv} | cut -d: -f2) ;\
+	done
+
+## validate-cr: Ensures the example CR is valid according to the CRD schema
+validate-cr:
+	${OPERATOR_DIR}/crd-docs/bin/validate-ossmplugin-cr.sh --cr-file ${OPERATOR_DIR}/crd-docs/cr/kiali.io_v1alpha1_ossmplugin.yaml
+
+## gen-crd-doc: Generates documentation for the OSSM Plugin CR configuration
+gen-crd-doc:
+	mkdir -p ${OPERATOR_OUTDIR}/crd-docs
+	${DORP} run -v ${OPERATOR_OUTDIR}/crd-docs:/opt/crd-docs-generator/output -v ${OPERATOR_DIR}/crd-docs/config:/opt/crd-docs-generator/config quay.io/giantswarm/crd-docs-generator:0.9.0 --config /opt/crd-docs-generator/config/apigen-config.yaml
+
+# Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
+# This does a few things:
+#  1. Makes sure docker is in PATH
+#  2. Downloads and installs buildx if no version of buildx is installed yet
+#  3. Makes sure any installed buildx is a required version or newer
+#  4. Makes sure the user has enabled buildx (either by default or by setting DOCKER_CLI_EXPERIMENTAL env var to 'enabled')
+#  Thus, this target will only ever succeed if a required (or newer) version of 'docker buildx' is available and enabled.
+.ensure-docker-buildx:
+	@if ! which docker > /dev/null 2>&1; then echo "'docker' is not in your PATH."; exit 1; fi
+	@required_buildx_version="0.4.2"; \
+	if ! DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version > /dev/null 2>&1 ; then \
+	  buildx_download_url="https://github.com/docker/buildx/releases/download/v$${required_buildx_version}/buildx-v$${required_buildx_version}.${GOOS}-${GOARCH}"; \
+	  echo "You do not have 'docker buildx' installed. Will now download from [$${buildx_download_url}] and install it to [${HOME}/.docker/cli-plugins]."; \
+	  mkdir -p ${HOME}/.docker/cli-plugins; \
+	  curl -L --output ${HOME}/.docker/cli-plugins/docker-buildx "$${buildx_download_url}"; \
+	  chmod a+x ${HOME}/.docker/cli-plugins/docker-buildx; \
+	  installed_version="$$(DOCKER_CLI_EXPERIMENTAL="enabled" docker buildx version || echo "unknown")"; \
+	  if docker buildx version > /dev/null 2>&1; then \
+	    echo "'docker buildx' has been installed and is enabled [version=$${installed_version}]"; \
+	  else \
+	    echo "An attempt to install 'docker buildx' has been made but it either failed or is not enabled by default. [version=$${installed_version}]"; \
+	    echo "Set DOCKER_CLI_EXPERIMENTAL=enabled to enable it."; \
+	    exit 1; \
+	  fi \
+	fi; \
+	current_buildx_version="$$(DOCKER_CLI_EXPERIMENTAL=enabled docker buildx version 2>/dev/null | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/g')"; \
+	is_valid_buildx_version="$$(if [ "$$(printf $${required_buildx_version}\\n$${current_buildx_version} | sort -V | head -n1)" == "$${required_buildx_version}" ]; then echo "true"; else echo "false"; fi)"; \
+	if [ "$${is_valid_buildx_version}" == "true" ]; then \
+	  echo "A valid version of 'docker buildx' is available: $${current_buildx_version}"; \
+	else \
+	  echo "You have an older version of 'docker buildx' that is not compatible. Please upgrade to at least v$${required_buildx_version}"; \
+	  exit 1; \
+	fi; \
+	if docker buildx version > /dev/null 2>&1; then \
+	  echo "'docker buildx' is enabled"; \
+	else \
+	  echo "'docker buildx' is not enabled. Set DOCKER_CLI_EXPERIMENTAL=enabled if you want to use it."; \
+	  exit 1; \
+	fi
+
+# Ensure a local builder for multi-arch build. For more details, see: https://github.com/docker/buildx/blob/master/README.md#building-multi-platform-images
+.ensure-buildx-builder: .ensure-docker-buildx
+	@if ! docker buildx inspect ossmplugin-builder > /dev/null 2>&1; then \
+	  echo "The buildx builder instance named 'ossmplugin-builder' does not exist. Creating one now."; \
+	  if ! docker buildx create --name=ossmplugin-builder --driver-opt=image=moby/buildkit:v0.8.0; then \
+	    echo "Failed to create the buildx builder 'ossmplugin-builder'"; \
+	    exit 1; \
+	  fi \
+	fi; \
+	if [[ $$(uname -s) == "Linux" ]]; then \
+	  echo "Ensuring QEMU is set up for this Linux host"; \
+	  if ! docker run --privileged --rm quay.io/kiali/binfmt:latest --install all; then \
+	    echo "Failed to ensure QEMU is set up. This build will be allowed to continue, but it may fail at a later step."; \
+	  fi \
+	fi
+
+## build-push-multi-arch: Pushes the OSSM Plugin Operator multi-arch image to quay.io.
+build-push-multi-arch: .ensure-buildx-builder
+	@echo Pushing OSSM Plugin Operator multi-arch image to ${OPERATOR_QUAY_TAG} using docker buildx
+	docker buildx build --build-arg OPERATOR_BASE_IMAGE_REPO=${OPERATOR_BASE_IMAGE_REPO} --build-arg OPERATOR_BASE_IMAGE_VERSION=${OPERATOR_BASE_IMAGE_VERSION} --push --pull --no-cache --builder=ossmplugin-builder $(foreach arch,${TARGET_ARCHS},--platform=linux/${arch}) $(foreach tag,${OPERATOR_QUAY_TAG},--tag=${tag}) -f ${OPERATOR_DIR}/build/Dockerfile ${OPERATOR_DIR}

--- a/make/Makefile.plugin.mk
+++ b/make/Makefile.plugin.mk
@@ -1,0 +1,36 @@
+#
+# Targets for building the plugin itself.
+#
+
+## clean-plugin: Delete generated code.
+clean-plugin:
+	@rm -rf ${PLUGIN_DIR}/node_modules
+	@rm -rf ${PLUGIN_DIR}/dist
+
+## build-plugin: Builds the plugin.
+build-plugin: clean-plugin
+	cd ${PLUGIN_DIR} && yarn install && yarn build
+
+## build-plugin-image: Builds the plugin container image.
+build-plugin-image:
+	cd ${PLUGIN_DIR} && ${DORP} build -t quay.io/kiali/servicemesh-plugin:latest .
+
+## build-plugin-push: Pushes the plugin container image to quay.io.
+build-plugin-push:
+	cd ${PLUGIN_DIR} && ${DORP} push quay.io/kiali/servicemesh-plugin:latest
+
+## deploy-plugin: Deploys the plugin quickly. This does not utilize the operator.
+deploy-plugin: .ensure-oc-login
+	cd ${PLUGIN_DIR} && ${OC} apply -f manifest.yaml
+
+## undeploy-plugin: Removes the plugin quickly. This does not utilize the operator.
+undeploy-plugin: .ensure-oc-login
+	cd ${PLUGIN_DIR} && ${OC} delete -f manifest.yaml
+
+## enable-plugin: Enables the plugin within the OpenShift Console.
+enable-plugin: .ensure-oc-login
+	${OC} patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["servicemesh"] } }' --type=merge
+
+## restart-plugin: Restarts the plugin.
+restart-plugin: .ensure-oc-login
+	${OC} rollout restart deployments/servicemesh-plugin -n servicemesh-plugin

--- a/operator/.gitignore
+++ b/operator/.gitignore
@@ -1,0 +1,2 @@
+_output/
+__pycache__/

--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -1,0 +1,19 @@
+ARG OPERATOR_BASE_IMAGE_VERSION
+ARG OPERATOR_BASE_IMAGE_REPO
+FROM ${OPERATOR_BASE_IMAGE_REPO}:${OPERATOR_BASE_IMAGE_VERSION}
+
+USER root
+# see https://github.com/operator-framework/operator-sdk/issues/5745
+RUN yum remove -y subscription-manager python3-subscription-manager-rhsm
+RUN yum update -y && yum clean all
+USER ${USER_UID}
+
+COPY roles/ ${HOME}/roles/
+COPY playbooks/ ${HOME}/playbooks/
+COPY watches.yaml ${HOME}/watches.yaml
+
+COPY requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
+
+RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callback_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg

--- a/operator/crd-docs/bin/validate-ossmplugin-cr.sh
+++ b/operator/crd-docs/bin/validate-ossmplugin-cr.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+##############################################################################
+# validate-ossmplugin-cr.sh
+#
+# This script can be used to validate a OSSMPlugin CR.
+#
+# To use this script, you must:
+# * Have "oc" or "kubectl"
+# * Be connected to a cluster
+# * Have cluster-admin rights
+#
+##############################################################################
+
+set -u
+
+crd() {
+  local crd_file=""
+
+  # if not specified, use the default location; otherwise, it is either a file or a URL
+  if [ -z "${OSSMPLUGIN_CRD_LOCATION:-}" ]; then
+    local script_root="$(cd "$(dirname "$0")" ; pwd -P)"
+    crd_file="${script_root}/../crd/kiali.io_ossmplugins.yaml"
+  elif [ -f "${OSSMPLUGIN_CRD_LOCATION}" ]; then
+    crd_file="${OSSMPLUGIN_CRD_LOCATION}"
+  fi
+  ([ -n "${crd_file}" ] && cat "${crd_file}" || curl -sL "${OSSMPLUGIN_CRD_LOCATION}") | sed 's/ name: ossmplugins.kiali.io/ name: testossmplugins.kiali.io/g' | sed 's/ kind: OSSMPlugin/ kind: TestOSSMPlugin/g' | sed 's/ listKind: OSSMPluginList/ listKind: TestOSSMPluginList/g' | sed 's/ plural: ossmplugins/ plural: testossmplugins/g' | sed 's/ singular: ossmplugin/ singular: testossmplugin/g'
+}
+
+# process command line args to override environment
+_CMD=""
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -ce|--client-exe)    CLIENT_EXE="$2"              ; shift;shift ;;
+    -crd|--crd-location) OSSMPLUGIN_CRD_LOCATION="$2" ; shift;shift ;;
+    -cf|--cr-file)       OSSMPLUGIN_CR_FILE="$2"      ; shift;shift ;;
+    -cn|--cr-name)       OSSMPLUGIN_CR_NAME="$2"      ; shift;shift ;;
+    -n|--namespace)      NAMESPACE="$2"               ; shift;shift ;;
+    -pc|--print-crd)     PRINT_CRD="$2"               ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+
+$0 [option...]
+
+  -ce|--client-exe
+      The path to the client executable. Should be a path to either a "oc" or "kubectl" executable.
+  -crd|--crd-location
+      The file or URL location where the OSSMPlugin CRD is. This CRD must include the schema.
+      If not specified, the internally defined CRD is used.
+  -cf|--cr-file
+      The file of the OSSMPlugin CR to test.
+  -cn|--cr-name
+      The name of an existing OSSMPlugin CR to test.
+  -n|--namespace
+      The namespace where the existing CR is or where the test CR will be created.
+      Default: "default"
+  -pc|--print-crd
+      If true, then this script will just print the CRD used to validate. It will not validate anything.
+      Default "false"
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key]. Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Set up some defaults
+
+: ${NAMESPACE:=default}
+: ${PRINT_CRD:=false}
+
+# If we are to print the CRD, do it now immediately and then exit. Nothing else to do.
+if [ "${PRINT_CRD}" == "true" ]; then
+  echo "$(crd)"
+  exit $?
+fi
+
+echo "=== SETTINGS ==="
+echo OSSMPLUGIN_CRD_LOCATION=${OSSMPLUGIN_CRD_LOCATION:-}
+echo OSSMPLUGIN_CR_FILE=${OSSMPLUGIN_CR_FILE:-}
+echo OSSMPLUGIN_CR_NAME=${OSSMPLUGIN_CR_NAME:-}
+echo NAMESPACE=${NAMESPACE}
+echo PRINT_CRD=${PRINT_CRD}
+echo "=== SETTINGS ==="
+
+# Determine what cluster client tool we are using.
+if [ -z "${CLIENT_EXE:-}" ]; then
+  if which oc &>/dev/null; then
+    CLIENT_EXE="$(which oc)"
+    echo "Using 'oc' located here: ${CLIENT_EXE}"
+  else
+    if which kubectl &>/dev/null; then
+      CLIENT_EXE="$(which kubectl)"
+      echo "Using 'kubectl' located here: ${CLIENT_EXE}"
+    else
+      echo "ERROR! You do not have 'oc' or 'kubectl' in your PATH. Please install it and retry."
+      exit 1
+    fi
+  fi
+else
+  echo "Client executable: ${CLIENT_EXE}"
+fi
+
+if [ -z "${OSSMPLUGIN_CR_FILE:-}" -a -z "${OSSMPLUGIN_CR_NAME:-}" ]; then
+  echo "ERROR! You must specify one of either --cr-file or --cr-name"
+  exit 1
+fi
+
+if [ -n "${OSSMPLUGIN_CR_FILE:-}" -a -n "${OSSMPLUGIN_CR_NAME:-}" ]; then
+  echo "ERROR! You must specify only one of either --cr-file or --cr-name"
+  exit 1
+fi
+
+if [ -n "${OSSMPLUGIN_CR_FILE:-}" -a ! -f "${OSSMPLUGIN_CR_FILE:-}" ]; then
+  echo "ERROR! OSSMPlugin CR file is not found: [${OSSMPLUGIN_CR_FILE:-}]"
+  exit 1
+fi
+
+if [ -n "${OSSMPLUGIN_CR_NAME:-}" ]; then
+  if ! ${CLIENT_EXE} get -n "${NAMESPACE}" ossmplugin "${OSSMPLUGIN_CR_NAME}" &> /dev/null; then
+    echo "ERROR! OSSMPlugin CR [${OSSMPLUGIN_CR_NAME}] does not exist in namespace [${NAMESPACE}]"
+    exit 1
+  fi
+fi
+
+# Make sure we have admin rights to some cluster
+if ! ${CLIENT_EXE} get namespaces &> /dev/null ; then
+  echo "ERROR! You must be connected to/logged into a cluster"
+  exit 1
+fi
+if [ "$(${CLIENT_EXE} auth can-i create crd --all-namespaces)" != "yes" ]; then
+  echo "ERROR! You must have cluster-admin permissions"
+  exit 1
+fi
+
+# install the test CRD with the schema
+if ! echo "$(crd)" | ${CLIENT_EXE} apply --validate=true --wait=true -f - &> /dev/null ; then
+  echo "ERROR! Failed to install the test CRD"
+  exit 1
+fi
+
+# wait for the test CRD to be established and then give k8s a few more seconds.
+# if we don't do this, the validation test may report a false negative.
+if ! ${CLIENT_EXE} wait --for condition=established --timeout=60s crd/testossmplugins.kiali.io &> /dev/null ; then
+  echo "WARNING! Test CRD is not established yet. The validation test may not produce accurate results."
+else
+  for s in 3 2 1; do echo -n "." ; sleep 1 ; done
+  echo
+fi
+
+# validate the CR by creating a test version of it
+echo "Validating the CR:"
+echo "----------"
+if [ -n "${OSSMPLUGIN_CR_FILE:-}" ]; then
+  if ! cat "${OSSMPLUGIN_CR_FILE}" | sed 's/kind: OSSMPlugin/kind: TestOSSMPlugin/g' | sed 's/- kiali.io\/finalizer//g' | kubectl apply -n ${NAMESPACE} -f - ; then
+    echo "----------"
+    echo "ERROR! Validation failed for OSSMPlugin CR [${OSSMPLUGIN_CR_FILE}]"
+  else
+    echo "----------"
+    echo "OSSMPlugin CR [${OSSMPLUGIN_CR_FILE}] is valid."
+  fi
+else
+  if ! ${CLIENT_EXE} get -n "${NAMESPACE}" ossmplugin "${OSSMPLUGIN_CR_NAME}" -o yaml | sed 's/kind: OSSMPlugin/kind: TestOSSMPlugin/g' | sed 's/- kiali.io\/finalizer//g' | kubectl apply -n "${NAMESPACE}" -f - ; then
+    echo "----------"
+    echo "ERROR! Validation failed for OSSMPlugin CR [${OSSMPLUGIN_CR_NAME}] in namespace [${NAMESPACE}]"
+  else
+    echo "----------"
+    echo "OSSMPlugin CR [${OSSMPLUGIN_CR_NAME}] in namespace [${NAMESPACE}] is valid."
+  fi
+fi
+
+# delete the test CRD (which deletes the test CR along with it)
+if ! echo "$(crd)" | ${CLIENT_EXE} delete --wait=true -f - &> /dev/null ; then
+  echo "ERROR! Failed to delete the test CRD. You should remove it manually."
+  exit 1
+fi

--- a/operator/crd-docs/config/apigen-config.yaml
+++ b/operator/crd-docs/config/apigen-config.yaml
@@ -1,0 +1,15 @@
+template_path: ./apigen-crd.template
+
+source_repositories:
+- url: https://github.com/kiali/openshift-servicemesh-plugin
+  organization: kiali
+  short_name: openshift-servicemesh-plugin
+  commit_reference: main
+  crd_paths:
+  - operator/crd-docs/crd
+  cr_paths:
+  - operator/crd-docs/cr
+  metadata:
+    ossmplugins.kiali.io:
+      owner:
+      - https://github.com/orgs/kiali/teams/maintainers

--- a/operator/crd-docs/config/apigen-crd.template
+++ b/operator/crd-docs/config/apigen-crd.template
@@ -1,0 +1,99 @@
+---
+title: {{ .Title }} CR Reference
+linkTitle: {{ .Title }} CR Reference
+description: |
+{{- if .Description }}
+{{ .Description | indent 2 }}
+{{- else }}
+  Reference page for the {{ .Title }} CR.
+  The OpenShift ServiceMesh Plugin Operator will watch for resources of this type and install the OSSM Plugin according to those resources' configurations.
+{{- end }}
+technical_name: {{ .NamePlural }}.{{ .Group }}
+source_repository: {{ .SourceRepository }}
+source_repository_ref: {{ .SourceRepositoryRef }}
+---
+
+{{ if .VersionSchemas }}
+{{ range $versionName, $versionSchema := .VersionSchemas }}
+<div class="crd-schema-version">
+
+{{with .ExampleCR}}
+<h3 id="example-cr">Example CR</h3>
+<em>(all values shown here are the defaults unless otherwise noted)</em>
+
+```yaml
+{{ .|raw -}}
+```
+{{end}}
+
+### Validating your OSSMPlugin CR
+
+A tool is available to allow you to check your own OSSMPlugin CR to ensure it is valid. Simply download [the validation script](https://raw.githubusercontent.com/kiali/openshift-servicemesh-plugin/main/operator/crd-docs/bin/validate-ossmplugin-cr.sh) and run it, passing in the location of the OSSMPlugin CRD you wish to validate with (e.g. the latest version is found [here](https://raw.githubusercontent.com/kiali/openshift-servicemesh-plugin/main/operator/crd-docs/crd/kiali.io_ossmplugins.yaml)) and the location of your OSSMPlugin CR. You must be connected to/logged into a cluster for this validation tool to work.
+
+For example, to validate a OSSMPlugin CR named `ossmplugin` in the namespace `istio-system` using the latest version of the OSSMPlugin CRD, run the following:
+<pre>
+bash <(curl -sL https://raw.githubusercontent.com/kiali/openshift-servicemesh-plugin/main/operator/crd-docs/bin/validate-ossmplugin-cr.sh) \
+  -crd https://raw.githubusercontent.com/kiali/openshift-servicemesh-plugin/main/operator/crd-docs/crd/kiali.io_ossmplugins.yaml \
+  --cr-name ossmplugin \
+  -n istio-system
+</pre>
+
+For additional help in using this validation tool, pass it the `--help` option.
+
+<h3 id="property-details">Properties</h3>
+
+{{ range $versionSchema.Properties }}
+<div class="property depth-{{.Depth}}">
+<div class="property-header">
+<hr/>
+<h3 class="property-path" id="{{.Path}}">{{.Path}}</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+{{with .Type}}<span class="property-type">({{.}})</span>{{end}}
+{{ if not .Required }}
+{{ else -}}
+<span class="property-required">*Required*</span>
+{{ end -}}
+</div>
+{{with .Description}}
+<div class="property-description">
+{{.|markdown}}
+</div>
+{{end}}
+</div>
+</div>
+{{ end }}
+
+
+{{ if .Annotations }}
+<h3 id="annotation-details">Annotations</h3>
+
+{{ range $versionSchema.Annotations }}
+<div class="annotation">
+<div class="annotation-header">
+<h3 class="annotation-path" id="{{.CRDVersion}}-{{.Annotation}}">{{.Annotation}}</h3>
+</div>
+<div class="annotation-body">
+<div class="annotation-meta">
+{{with .Release}}<span class="annotation-release">{{.}}</span>{{end}}
+</div>
+{{with .Documentation}}
+<div class="annotation-description">
+{{.|markdown}}
+</div>
+{{end}}
+</div>
+</div>
+{{ end }}
+{{ end }}
+
+</div>
+{{end}}
+
+{{ else }}
+<div class="crd-noversions">
+<p>We currently cannot show any schema information on this <abbr title="custom resource definition">CRD</abbr>. Sorry for the inconvenience!</p>
+<p>Please refer to <a href="https://kiali.io">Kiali Documentation</a>.</p>
+</div>
+{{ end }}

--- a/operator/crd-docs/cr/kiali.io_v1alpha1_ossmplugin.yaml
+++ b/operator/crd-docs/cr/kiali.io_v1alpha1_ossmplugin.yaml
@@ -1,0 +1,20 @@
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: "1"
+spec:
+  version: "default"
+
+  deployment:
+    imageDigest: ""
+    imageName: ""
+    imagePullPolicy: "IfNotPresent"
+    # default: image_pull_secrets is an empty list
+    imagePullSecrets: ["image.pull.secret"]
+    imageVersion: ""
+    namespace: ""
+
+  kiali:
+    url: ""

--- a/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
+++ b/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
@@ -1,0 +1,90 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ossmplugins.kiali.io
+spec:
+  group: kiali.io
+  names:
+    kind: OSSMPlugin
+    listKind: OSSMPluginList
+    plural: ossmplugins
+    singular: ossmplugin
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          status:
+            description: "The processing status of this CR as reported by the operator."
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          spec:
+            description: "This is the CRD for the resources called OSSMPlugin CRs. The OpenShift ServiceMesh Plugin Operator will watch for resources of this type and when it detects a OSSMPlugin CR has been added, deleted, or modified, it will install, uninstall, and update the associated OSSM Plugin installation."
+            type: object
+            properties:
+              version:
+                description: |
+                  The version of the Ansible playbook to execute in order to install that version of OSSM Plugin.
+                  It is rare you will want to set this - if you are thinking of setting this, know what you are doing first.
+                  The only supported value today is `default`.
+                  If not specified, a default version of Kiali will be installed which will be the most recent release of Kiali.
+                  Refer to this file to see where these values are defined in the master branch,
+                  https://github.com/kiali/openshift-servicemesh-plugin/tree/main/operator/playbooks/default-supported-images.yml
+                  This version setting affects the defaults of the deployment.imageName and
+                  deployment.imageVersion settings. See the comments for those settings
+                  below for additional details. But in short, this version setting will
+                  dictate which version of the OSSM Plugin image will be deployed by default.
+                  Note that if you explicitly set deployment.imageName and/or
+                  deployment.imageVersion you are responsible for ensuring those settings
+                  are compatible with this setting (i.e. the image must be compatible
+                  with the rest of the configuration and resources the operator will install).
+                type: string
+              deployment:
+                type: object
+                properties:
+                  imageDigest:
+                    description: "If `deployment.imageVersion` is a digest hash, this value indicates what type of digest it is. A typical value would be 'sha256'. Note: do NOT prefix this value with a '@'."
+                    type: string
+                  imageName:
+                    description: "Determines which OSSM Plugin image to download and install. If you set this to a specific name (i.e. you do not leave it as the default empty string), you must make sure that image is supported by the operator. If empty, the operator will use a known supported image name based on which `version` was defined. Note that, as a security measure, a cluster admin may have configured the OSSM Plugin operator to ignore this setting. A cluster admin may do this to ensure the OSSM Plugin operator only installs a single, specific OSSM Plugin version, thus this setting may have no effect depending on how the operator itself was configured."
+                    type: string
+                  imagePullPolicy:
+                    description: "The Kubernetes pull policy for the OSSM Plugin deployment. This is overridden to be 'Always' if `deployment.imageVersion` is set to 'latest'."
+                    type: string
+                  imagePullSecrets:
+                    description: "The names of the secrets to be used when container images are to be pulled."
+                    type: array
+                    items:
+                      type: string
+                  imageVersion:
+                    description: |
+                      Determines which version of OSSM Plugin to install.
+                      Choose 'lastrelease' to use the last Kiali release.
+                      Choose 'latest' to use the latest image (which may or may not be a released version of Kiali).
+                      Choose 'operator_version' to use the image whose version is the same as the operator version.
+                      Otherwise, you can set this to any valid OSSM Plugin version (such as 'v1.0') or any valid OSSM Plugin
+                      digest hash (if you set this to a digest hash, you must indicate the digest in `deployment.imageDigest`).
+                      Note that if this is set to 'latest' then the `deployment.imagePullPolicy` will be set to 'Always'.
+                      If you set this to a specific version (i.e. you do not leave it as the default empty string),
+                      you must make sure that image is supported by the operator.
+                      If empty, the operator will use a known supported image version based on which 'version' was defined.
+                      Note that, as a security measure, a cluster admin may have configured the OSSM Plugin operator to
+                      ignore this setting. A cluster admin may do this to ensure the OSSM Plugin operator only installs
+                      a single, specific OSSM Plugin version, thus this setting may have no effect depending on how the
+                      operator itself was configured.
+                    type: string
+                  namespace:
+                    description: "The namespace into which OSSM Plugin is to be installed. If this is empty or not defined, the default will be the namespace where the OSSMPlugin CR is located."
+                    type: string
+              kiali:
+                type: object
+                properties:
+                  url:
+                    description: "The main Kiali endpoint URL that the OSSM Plugin will use to communicate with Kiali."
+                    type: string

--- a/operator/deploy/ossmplugin-cr-dev.yaml
+++ b/operator/deploy/ossmplugin-cr-dev.yaml
@@ -1,0 +1,14 @@
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin
+  namespace: ossmplugin
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: "1"
+spec:
+  version: default
+  deployment:
+    imageName: quay.io/kiali/servicemesh-plugin
+    imageVersion: latest
+  kiali:
+    url: ${KIALI_URL}

--- a/operator/deploy/ossmplugin-cr-minimal.yaml
+++ b/operator/deploy/ossmplugin-cr-minimal.yaml
@@ -1,0 +1,4 @@
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin

--- a/operator/dev-playbook-config/README.adoc
+++ b/operator/dev-playbook-config/README.adoc
@@ -1,0 +1,7 @@
+The files in this directory are used for the `make run-operator-playbook` target. Configure these files to tell the operator playbook what to do when that target is executed.
+
+* `dev-hosts.yaml` - the Ansible inventory file. This should contain variables that the operator SDK would normally set when triggering an operator reconciliation run. Note that most of the values here will be values that mimic the values in the OSSMPlugin CR. You typically will want to make sure the values in `dev-ossmplugin-cr.yaml` match those in this `dev-hosts.yaml` file.
+
+* `dev-ossmplugin-cr.yaml` - the "dummy" OSSMPlugin CR that will be created. This is needed because the operator will sometimes need to access the OSSMPlugin CR that is being reconciled, so one needs to be created in the cluster for the operator to run correctly. In particular, the operator will update the `status` field of the OSSMPlugin CR.
+
+* `dev-playbook.yaml` - the main playbook that will be run. By default it will run the `ossmplugin-deploy` playbook (which will install a OSSM Plugin) and then immediately run the `ossmplugin-remove` playbook (which will uninstall that OSSM Plugin). You can comment out one or the other if you wish to test just one of those playbooks.

--- a/operator/dev-playbook-config/dev-hosts.yaml
+++ b/operator/dev-playbook-config/dev-hosts.yaml
@@ -1,0 +1,33 @@
+all:
+  vars:
+
+    # Mimic OSSMPlugin CR settings found in dev-ossmplugin-cr.yaml
+
+    version: default
+
+    deployment:
+      imageVersion: dev
+
+    kiali:
+      url: https://kiali-istio-system.apps-crc.testing
+
+    # The Operator SDK creates a "ansible_operator_meta" variable
+    # that contains the name and namespace of the CR.
+    # Most times you can just run with these defaults.
+    # Make sure these match those in dev-ossmplugin-cr.yaml.
+
+    ansible_operator_meta:
+      name: ossmplugin
+      namespace: dev-ossmplugin
+
+    # The Operator SDK creates a "_kiali_io_ossmplugin" variable that
+    # mimics the OSSMPlugin CR but maintains camelCase in key names.
+    # The operator playbook expects this defined.
+    # Make sure these match those in dev-ossmplugin-cr.yaml.
+
+    _kiali_io_ossmplugin:
+      apiVersion: kiali.io/v1alpha1
+      kind: OSSMPlugin
+      metadata:
+        name: ossmplugin
+        namespace: dev-ossmplugin

--- a/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
+++ b/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev-ossmplugin
+---
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin
+  namespace: dev-ossmplugin
+  annotations:
+    ansible.sdk.operatorframework.io/verbosity: "1"
+  labels:
+    kiali.dev: "run-operator-playbook"
+spec:
+
+  # Make sure the values below also match those in dev-hosts.yaml
+
+  version: default
+
+  deployment:
+    imageVersion: dev
+
+  kiali:
+    url: https://kiali-istio-system.apps-crc.testing

--- a/operator/dev-playbook-config/dev-playbook.yaml
+++ b/operator/dev-playbook-config/dev-playbook.yaml
@@ -1,0 +1,3 @@
+---
+- import_playbook: ../playbooks/ossmplugin-deploy.yml
+- import_playbook: ../playbooks/ossmplugin-remove.yml

--- a/operator/hello-world-operator.txt
+++ b/operator/hello-world-operator.txt
@@ -1,1 +1,0 @@
-A shiny and new Operator will be placed here.

--- a/operator/manifests/create-new-version.sh
+++ b/operator/manifests/create-new-version.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+VERIFY_BUNDLE="true"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -nv|--new-version)              NEW_VERSION="$2"            ; shift;shift ;;
+    -opin|--operator-image-name)    OPERATOR_IMAGE_NAME="$2"    ; shift;shift ;;
+    -opiv|--operator-image-version) OPERATOR_IMAGE_VERSION="$2" ; shift;shift ;;
+    -ov|--old-version)              OLD_VERSION="$2"            ; shift;shift ;;
+    -vb|--verify-bundle)            VERIFY_BUNDLE="$2"          ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+$0 [option...]
+
+Valid options:
+  -nv|--new-version <version string>
+      The new version that is going to be released. New manifest files for this version will be created.
+  -opin|--operator-image-name <repo/org/name>
+      The full image registry name of the operator without the version tag.
+      Default: quay.io/kiali/ossmplugin-operator
+  -opiv|--operator-image-version <version>
+      The version tag that identifies the operator image that is used by the new manifest.
+      Default: <the --new-version value> prefixed with "v"
+  -ov|--old-version <version string>
+      The old version that is going to be superceded with the new release. This must be the previous release
+      prior to the new version. For example, if there is already versions 1.0 and 1.1 and the new version is
+      2.0, the old version to be specified must be 1.1.
+  -vb|--verify-bundle <true|false>
+      Verify the validity of the bundle metadata via the operator-sdk tool. You must have operator-sdk
+      installed and in your PATH or in _output for this to work (make get-operator-sdk).
+      Default: true
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key].  Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Validate some things before trying to do anything
+TEMPLATE_MANIFEST_DIR="${SCRIPT_DIR}/template"
+if [ ! -d "${TEMPLATE_MANIFEST_DIR:-!notvalid!}" ]; then
+  echo "Something is wrong. The template directory is missing in ${SCRIPT_DIR}"
+  exit 1
+fi
+
+if [ -z "${NEW_VERSION}" ]; then
+  echo "You must specify a new version."
+  exit 1
+fi
+
+if [ -z "${OLD_VERSION}" ]; then
+  echo "You must specify an old version."
+  exit 1
+fi
+
+if [ "${VERIFY_BUNDLE}" == "true" ]; then
+  if which operator-sdk > /dev/null 2>&1 ; then
+    OPERATOR_SDK="operator-sdk"
+  elif [ -x "${SCRIPT_DIR}/../_output/operator-sdk-install/operator-sdk" ]; then
+    OPERATOR_SDK="${SCRIPT_DIR}/../_output/operator-sdk-install/operator-sdk"
+  fi
+
+  if ! "${OPERATOR_SDK}" version &> /dev/null; then
+    echo "You do not have operator-sdk in your PATH or in _output. Cannot verify the metadata."
+    echo "To disable this check, use the '--verify-manifest=false' option."
+    exit 1
+  fi
+fi
+
+OLD_MANIFEST_DIR="${SCRIPT_DIR}/ossmplugin-community/${OLD_VERSION}"
+NEW_MANIFEST_DIR="${SCRIPT_DIR}/ossmplugin-community/${NEW_VERSION}"
+
+OPERATOR_IMAGE_NAME="${OPERATOR_IMAGE_NAME:-quay.io/kiali/ossmplugin-operator}"
+OPERATOR_IMAGE_VERSION="${OPERATOR_IMAGE_VERSION:-v${NEW_VERSION}}"
+
+if [ ! -d "${OLD_MANIFEST_DIR}" ]; then
+  echo "Did not find the old version of the manifest: ${OLD_MANIFEST_DIR}"
+  exit 1
+fi
+if [ -d "${NEW_MANIFEST_DIR}" ]; then
+  echo "There is already a new version of the manifest: ${NEW_MANIFEST_DIR}"
+  exit 1
+fi
+
+# Create a new version directory, starting it out as a copy of the template directory
+mkdir -p "${NEW_MANIFEST_DIR}"
+if ! cp -R "${TEMPLATE_MANIFEST_DIR}"/* "${NEW_MANIFEST_DIR}"; then
+  echo "Failed to copy the template content in [${TEMPLATE_MANIFEST_DIR}] to the new manifest directory [${NEW_MANIFEST_DIR}]"
+  exit 1
+fi
+
+# Generate the new content, overwriting the template
+
+CSV_YAML="$(ls -1 ${NEW_MANIFEST_DIR}/manifests/*.clusterserviceversion.yaml)"
+if [ -z ${CSV_YAML} ]; then
+  echo "Cannot find the CSV yaml file"
+  exit 1
+fi
+${SCRIPT_DIR}/generate-csv.sh -nv ${NEW_VERSION} -ov ${OLD_VERSION} -opin ${OPERATOR_IMAGE_NAME} -opiv ${OPERATOR_IMAGE_VERSION} > ${CSV_YAML}
+
+# Verify the correctness using operator-sdk tool
+
+if [ "${VERIFY_BUNDLE}" == "true" ]; then
+  echo "Verifying the correctness of the bundle metadata via: ${OPERATOR_SDK} bundle validate ${NEW_MANIFEST_DIR}"
+  if ! "${OPERATOR_SDK}" bundle validate "${NEW_MANIFEST_DIR}" ; then
+    echo "Failed to verify the bundle metadata. Check the errors and correct them before publishing the bundle."
+    exit 1
+  fi
+else
+  echo "Skipping bundle verification"
+fi
+
+# Completed!
+
+echo "New manifest bundle: ${NEW_MANIFEST_DIR}"
+ls ${NEW_MANIFEST_DIR}
+echo

--- a/operator/manifests/generate-csv.sh
+++ b/operator/manifests/generate-csv.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -nv|--new-version)              NEW_VERSION="$2"            ; shift;shift ;;
+    -opin|--operator-image-name)    OPERATOR_IMAGE_NAME="$2"    ; shift;shift ;;
+    -opiv|--operator-image-version) OPERATOR_IMAGE_VERSION="$2" ; shift;shift ;;
+    -ov|--old-version)              OLD_VERSION="$2"            ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+$0 [option...]
+
+Using the settings passed to this script, this will print to stdout a new CSV generated from the template CSV.
+
+Valid options:
+  -nv|--new-version <version string>
+      The new version of the CSV.
+  -opin|--operator-image-name <repo/org/name>
+      The full image registry name of the operator without the version tag.
+      Default: quay.io/kiali/ossmplugin-operator
+  -opiv|--operator-image-version <version>
+      The version tag that identifies the operator image that is used by the new manifest.
+      Default: <the --new-version value> prefixed with "v"
+  -ov|--old-version <version string>
+      The old version of the CSV that is going to be superceded with the new version.
+      If there is no previous version, pass in "NONE". This is only useful when generating a
+      CSV for an index that will have only a single bundle (e.g. for dev environments).
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key].  Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Validate some things before trying to do anything
+TEMPLATE_MANIFEST_DIR="${SCRIPT_DIR}/template"
+if [ ! -d "${TEMPLATE_MANIFEST_DIR:-!notvalid!}" ]; then
+  echo "Something is wrong. The template directory is missing in ${SCRIPT_DIR}"
+  exit 1
+fi
+
+if [ -z "${NEW_VERSION:-}" ]; then
+  echo "You must specify a new CSV version."
+  exit 1
+fi
+
+if [ -z "${OLD_VERSION:-}" ]; then
+  echo "You must specify an old CSV version."
+  exit 1
+fi
+
+# strip off any "v" prefix - CSV versions do not have "v" in their version strings.
+NEW_VERSION="$(echo -n ${NEW_VERSION} | sed 's/^v//')"
+OLD_VERSION="$(echo -n ${OLD_VERSION} | sed 's/^v//')"
+
+# determine what the operator image is
+OPERATOR_IMAGE_VERSION="${OPERATOR_IMAGE_VERSION:-v${NEW_VERSION}}"
+OPERATOR_IMAGE_NAME="${OPERATOR_IMAGE_NAME:-quay.io/kiali/ossmplugin-operator}"
+
+CSV_YAML="$(ls -1 ${SCRIPT_DIR}/template/manifests/*.clusterserviceversion.yaml)"
+if [ -z ${CSV_YAML} ]; then
+  echo "Cannot find the template CSV yaml file"
+  exit 1
+fi
+
+# Generate the new CSV content from the template
+if [ "${OLD_VERSION}" == "NONE" ]; then
+  CSV_REPLACES_COMMENT="#"
+fi
+export CSV_NEW_VERSION="${NEW_VERSION}"
+export CSV_PREVIOUS_VERSION="${OLD_VERSION}"
+export CSV_REPLACES_COMMENT
+export OPERATOR_IMAGE_NAME
+export OPERATOR_IMAGE_VERSION
+export CREATED_AT="$(date --utc +'%FT%TZ')"
+cat ${CSV_YAML} | envsubst

--- a/operator/manifests/ossmplugin-community/0.0.1/bundle.Dockerfile
+++ b/operator/manifests/ossmplugin-community/0.0.1/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ossmplugin
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
@@ -32,11 +32,11 @@ spec:
   version: 0.0.1
   maturity: alpha
   #replaces: ossmplugin-operator.v0.0.1
-  displayName: OSSM Plugin Operator
+  displayName: OpenShift Service Mesh Plugin
   description: |-
     ## About the managed application
 
-    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+    The OpenShift Service Mesh Plugin adds Kiali functionality to the OpenShift Console.
 
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
@@ -68,7 +68,7 @@ spec:
     owned:
     - name: ossmplugins.kiali.io
       group: kiali.io
-      description: A configuration file for a OSSM Plugin installation.
+      description: A configuration file for a OpenShift Service Mesh Plugin installation.
       displayName: OpenShift ServiceMesh Plugin
       kind: OSSMPlugin
       version: v1alpha1

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
@@ -1,0 +1,244 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ossmplugin-operator.v0.0.1
+  namespace: placeholder
+  annotations:
+    #olm.skipRange: '>=0.0.1 <0.0.1'
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/ossmplugin-operator:v0.0.1
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/openshift-servicemesh-plugin
+    createdAt: 2022-06-01T00:00:00Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "OSSMPlugin",
+          "metadata": {
+            "name": "ossmplugin"
+          },
+          "spec": {
+            "kiali": {
+              "url": "https://kiali-istio-system.apps-crc.testing"
+            }
+          }
+        }
+      ]
+spec:
+  version: 0.0.1
+  maturity: alpha
+  #replaces: ossmplugin-operator.v0.0.1
+  displayName: OSSM Plugin Operator
+  description: |-
+    ## About the managed application
+
+    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio', 'kiali', 'ossm']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: ossmplugin-operator
+  selector:
+    matchLabels:
+      name: ossmplugin-operator
+  links:
+  - name: Operator Source Code
+    url: https://github.com/kiali/openshift-servicemesh-plugin
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: ossmplugins.kiali.io
+      group: kiali.io
+      description: A configuration file for a OSSM Plugin installation.
+      displayName: OpenShift ServiceMesh Plugin
+      kind: OSSMPlugin
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      specDescriptors: []
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: ossmplugin-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ossmplugin-operator
+          template:
+            metadata:
+              name: ossmplugin-operator
+              labels:
+                app: ossmplugin-operator
+                # required for the operator SDK metric service selector
+                name: ossmplugin-operator
+                version: v0.0.1
+                app.kubernetes.io/name: ossmplugin-operator
+                app.kubernetes.io/instance: ossmplugin-operator
+                app.kubernetes.io/version: v0.0.1
+                app.kubernetes.io/part-of: ossmplugin-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: ossmplugin-operator
+              containers:
+              - name: operator
+                image: quay.io/kiali/ossmplugin-operator:v0.0.1
+                imagePullPolicy: "Always"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=ossmplugin-operator"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_OSSMPLUGIN_IMAGE
+                  value: "false"
+                - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+                  value: "100"
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_OSSMPLUGIN_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consoleplugins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["operator.openshift.io"]
+          resources:
+          - consoles
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - ossmplugin-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        serviceAccountName: ossmplugin-operator

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.crd.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ossmplugins.kiali.io
+  labels:
+    app: ossmplugin-operator
+spec:
+  group: kiali.io
+  names:
+    kind: OSSMPlugin
+    listKind: OSSMPluginList
+    plural: ossmplugins
+    singular: ossmplugin
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/operator/manifests/ossmplugin-community/0.0.1/metadata/annotations.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ossmplugin

--- a/operator/manifests/ossmplugin-community/ci.yaml
+++ b/operator/manifests/ossmplugin-community/ci.yaml
@@ -1,0 +1,5 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode
+reviewers:
+- jmazzitelli

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
@@ -1,0 +1,254 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ossmplugin-operator.v${OSSMPLUGIN_OPERATOR_VERSION}
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+  annotations:
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    olm.skipRange: '>=0.0.1 <${OSSMPLUGIN_OPERATOR_VERSION}'
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ossmplugin-rhel8-operator:${OSSMPLUGIN_OPERATOR_VERSION}
+    capabilities: Basic Install
+    support: Red Hat
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/openshift-servicemesh-plugin
+    createdAt: ${CREATED_AT}
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "OSSMPlugin",
+          "metadata": {
+            "name": "ossmplugin"
+          },
+          "spec": {
+            "kiali": {
+              "url": "https://kiali-istio-system.apps-crc.testing "
+            }
+          }
+        }
+      ]
+spec:
+  version: ${OSSMPLUGIN_OPERATOR_VERSION}
+  maturity: alpha
+  #replaces: ossmplugin-operator.v${OSSMPLUGIN_OLD_OPERATOR_VERSION}
+  displayName: OSSM Plugin Operator
+  description: |-
+    ## About the managed application
+
+    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio', 'kiali', 'ossm']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Red Hat
+  labels:
+    name: ossmplugin-operator
+  selector:
+    matchLabels:
+      name: ossmplugin-operator
+  links:
+  - name: Operator Source Code
+    url: https://github.com/kiali/openshift-servicemesh-plugin
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: ossmplugins.kiali.io
+      group: kiali.io
+      description: A configuration file for a OSSM Plugin installation.
+      displayName: OpenShift ServiceMesh Plugin
+      kind: OSSMPlugin
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      specDescriptors: []
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: ossmplugin-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ossmplugin-operator
+          template:
+            metadata:
+              name: ossmplugin-operator
+              labels:
+                app: ossmplugin-operator
+                # required for the operator SDK metric service selector
+                name: ossmplugin-operator
+                version: v${OSSMPLUGIN_OPERATOR_VERSION}
+                app.kubernetes.io/name: ossmplugin-operator
+                app.kubernetes.io/instance: ossmplugin-operator
+                app.kubernetes.io/version: v${OSSMPLUGIN_OPERATOR_VERSION}
+                app.kubernetes.io/part-of: ossmplugin-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: ossmplugin-operator
+              containers:
+              - name: operator
+                image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ossmplugin-rhel8-operator${OSSMPLUGIN_OPERATOR_TAG}
+                imagePullPolicy: "Always"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=ossmplugin-operator"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_OSSMPLUGIN_IMAGE
+                  value: "false"
+                - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+                  value: "100"
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_OSSMPLUGIN_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                - name: RELATED_IMAGE_ossmplugin_default
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ossmplugin-rhel8${KIALI_0_1_TAG}"
+                - name: RELATED_IMAGE_ossmplugin_v0_1
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ossmplugin-rhel8${KIALI_0_1_TAG}"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consoleplugins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["operator.openshift.io"]
+          resources:
+          - consoles
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - ossmplugin-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        serviceAccountName: ossmplugin-operator

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
@@ -38,11 +38,11 @@ spec:
   version: ${OSSMPLUGIN_OPERATOR_VERSION}
   maturity: alpha
   #replaces: ossmplugin-operator.v${OSSMPLUGIN_OLD_OPERATOR_VERSION}
-  displayName: OSSM Plugin Operator
+  displayName: OpenShift Service Mesh Plugin
   description: |-
     ## About the managed application
 
-    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+    The OpenShift Service Mesh Plugin adds Kiali functionality to the OpenShift Console.
 
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
@@ -74,7 +74,7 @@ spec:
     owned:
     - name: ossmplugins.kiali.io
       group: kiali.io
-      description: A configuration file for a OSSM Plugin installation.
+      description: A configuration file for a OpenShift Service Mesh Plugin installation.
       displayName: OpenShift ServiceMesh Plugin
       kind: OSSMPlugin
       version: v1alpha1

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.crd.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ossmplugins.kiali.io
+  labels:
+    app: ossmplugin-operator
+spec:
+  group: kiali.io
+  names:
+    kind: OSSMPlugin
+    listKind: OSSMPluginList
+    plural: ossmplugins
+    singular: ossmplugin
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/operator/manifests/ossmplugin-ossm/metadata/annotations.yaml
+++ b/operator/manifests/ossmplugin-ossm/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ossmplugin-ossm

--- a/operator/manifests/prepare-community-prs.sh
+++ b/operator/manifests/prepare-community-prs.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+################################################
+# This script prepares a new branch in the
+# community operator git repo. You can create a
+# PR based on the branch this script creates.
+#
+# You must have forked the following repo:
+# * https://github.com/redhat-openshift-ecosystem/community-operators-prod
+#
+# This script uses legacy terminology.
+# Where you see "community", that means the Red Hat (community-operators-prod) metadata.
+################################################
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+DEFAULT_GIT_REPO_REDHAT=${SCRIPT_DIR}/../../../../community-operators/community-operators-prod
+GIT_REPO_REDHAT=${DEFAULT_GIT_REPO_REDHAT}
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -gr|--gitrepo-redhat)      GIT_REPO_REDHAT="$2"      ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+$0 [option...]
+
+Valid options:
+  -gr|--gitrepo-redhat <directory>
+      The directory where the local community-operators-prod git repo is located.
+      This is the location where you git cloned the repo https://github.com/redhat-openshift-ecosystem/community-operators-prod
+      Default: ${DEFAULT_GIT_REPO_REDHAT}
+      which resolves to:
+      $(readlink -f ${DEFAULT_GIT_REPO_REDHAT} || echo '<git repo does not exist at the default location>')
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key].  Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+# Validate some things before trying to do anything
+
+if [ ! -d "${GIT_REPO_REDHAT}" ]; then
+  echo "You must specify a valid community-operators-prod git repo: ${GIT_REPO_REDHAT}"
+  exit 1
+fi
+
+COMMUNITY_MANIFEST_DIR="${SCRIPT_DIR}/ossmplugin-community"
+
+if [ ! -d "${COMMUNITY_MANIFEST_DIR}" ]; then
+  echo "Did not find the community manifest directory: ${COMMUNITY_MANIFEST_DIR}"
+  exit 1
+fi
+
+# Determine branch names to use for the new data.
+
+DATETIME_NOW="$(date --utc +'%F-%H-%M-%S')"
+GIT_REPO_COMMUNITY_BRANCH_NAME="ossmplugin-community-${DATETIME_NOW}"
+
+cd ${GIT_REPO_REDHAT}
+git fetch origin --verbose
+git checkout -b ${GIT_REPO_COMMUNITY_BRANCH_NAME} origin/main
+cp -R ${COMMUNITY_MANIFEST_DIR}/* ${GIT_REPO_REDHAT}/operators/ossmplugin
+git add -A
+git commit --signoff -m '[ossmplugin] update ossmplugin'
+
+# Completed!
+echo "New OSSMPlugin metadata has been added to a new branch in the community git repo."
+echo "Create a PR based on this branch:"
+echo "1. cd ${GIT_REPO_REDHAT} && git push <your git remote name> ${GIT_REPO_COMMUNITY_BRANCH_NAME}"

--- a/operator/manifests/template/bundle.Dockerfile
+++ b/operator/manifests/template/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ossmplugin
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
@@ -32,11 +32,11 @@ spec:
   version: ${CSV_NEW_VERSION}
   maturity: alpha
   ${CSV_REPLACES_COMMENT}replaces: ossmplugin-operator.v${CSV_PREVIOUS_VERSION}
-  displayName: OSSM Plugin Operator
+  displayName: OpenShift Service Mesh Plugin
   description: |-
     ## About the managed application
 
-    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+    The OpenShift Service Mesh Plugin adds Kiali functionality to the OpenShift Console.
 
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
@@ -68,7 +68,7 @@ spec:
     owned:
     - name: ossmplugins.kiali.io
       group: kiali.io
-      description: A configuration file for a OSSM Plugin installation.
+      description: A configuration file for a OpenShift Service Mesh Plugin installation.
       displayName: OpenShift ServiceMesh Plugin
       kind: OSSMPlugin
       version: v1alpha1

--- a/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
@@ -1,0 +1,244 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ossmplugin-operator.v${CSV_NEW_VERSION}
+  namespace: placeholder
+  annotations:
+    #olm.skipRange: '>=0.0.1 <${CSV_NEW_VERSION}'
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: ${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}
+    capabilities: Basic Install
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/openshift-servicemesh-plugin
+    createdAt: ${CREATED_AT}
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "OSSMPlugin",
+          "metadata": {
+            "name": "ossmplugin"
+          },
+          "spec": {
+            "kiali": {
+              "url": "https://kiali-istio-system.apps-crc.testing"
+            }
+          }
+        }
+      ]
+spec:
+  version: ${CSV_NEW_VERSION}
+  maturity: alpha
+  ${CSV_REPLACES_COMMENT}replaces: ossmplugin-operator.v${CSV_PREVIOUS_VERSION}
+  displayName: OSSM Plugin Operator
+  description: |-
+    ## About the managed application
+
+    The OSSM Plugin adds Kiali functionality to the OpenShift Console.
+
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio', 'kiali', 'ossm']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: ossmplugin-operator
+  selector:
+    matchLabels:
+      name: ossmplugin-operator
+  links:
+  - name: Operator Source Code
+    url: https://github.com/kiali/openshift-servicemesh-plugin
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: ossmplugins.kiali.io
+      group: kiali.io
+      description: A configuration file for a OSSM Plugin installation.
+      displayName: OpenShift ServiceMesh Plugin
+      kind: OSSMPlugin
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      specDescriptors: []
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: ossmplugin-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ossmplugin-operator
+          template:
+            metadata:
+              name: ossmplugin-operator
+              labels:
+                app: ossmplugin-operator
+                # required for the operator SDK metric service selector
+                name: ossmplugin-operator
+                version: v${CSV_NEW_VERSION}
+                app.kubernetes.io/name: ossmplugin-operator
+                app.kubernetes.io/instance: ossmplugin-operator
+                app.kubernetes.io/version: v${CSV_NEW_VERSION}
+                app.kubernetes.io/part-of: ossmplugin-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: ossmplugin-operator
+              containers:
+              - name: operator
+                image: ${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}
+                imagePullPolicy: "Always"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=ossmplugin-operator"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_OSSMPLUGIN_IMAGE
+                  value: "false"
+                - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+                  value: "100"
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_OSSMPLUGIN_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consoleplugins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["operator.openshift.io"]
+          resources:
+          - consoles
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - ossmplugin-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        serviceAccountName: ossmplugin-operator

--- a/operator/manifests/template/manifests/ossmplugin.crd.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ossmplugins.kiali.io
+  labels:
+    app: ossmplugin-operator
+spec:
+  group: kiali.io
+  names:
+    kind: OSSMPlugin
+    listKind: OSSMPluginList
+    plural: ossmplugins
+    singular: ossmplugin
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/operator/manifests/template/metadata/annotations.yaml
+++ b/operator/manifests/template/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ossmplugin

--- a/operator/molecule/README.md
+++ b/operator/molecule/README.md
@@ -1,0 +1,3 @@
+# Running OSSMPlugin Operator Molecule Tests
+
+[Molecule](https://github.com/ansible-community/molecule) is used to test the operator.

--- a/operator/molecule/common/set_ossmplugin_cr.yml
+++ b/operator/molecule/common/set_ossmplugin_cr.yml
@@ -1,0 +1,4 @@
+- name: Change OSSMPlugin CR with new OSSMPlugin CR
+  k8s:
+    namespace: '{{ cr_namespace }}'
+    definition: "{{ new_ossmplugin_cr }}"

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -1,0 +1,59 @@
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup('kubernetes.core.k8s', cluster_info='api_groups') }}"
+- name: Determine the cluster type
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+    is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
+    is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
+- name: Determine the Istio implementation
+  set_fact:
+    is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
+
+- name: Get SMCP if running in Maistra environment
+  k8s_info:
+    api_version: maistra.io/v2
+    kind: ServiceMeshControlPlane
+    namespace: "{{ istio.control_plane_namespace }}"
+  register: maistra_smcp
+  when:
+  - is_maistra == True
+
+- name: There must one and only one SMCP already installed in the control plane
+  set_fact:
+    maistra_smcp: "{{ maistra_smcp.resources[0] }}"
+  when:
+  - is_maistra == True
+
+- name: Get OSSMPlugin CR if present
+  set_fact:
+    ossmplugin_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMPlugin', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+- name: Get OSSMPlugin Operator Pod
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ ossmplugin.operator_namespace }}"
+    label_selectors:
+    - app.kubernetes.io/name = ossmplugin-operator
+  register: ossmplugin_operator_pod
+
+- name: Get OSSMPlugin Pod
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ ossmplugin.install_namespace }}"
+    label_selectors:
+    - "app.kubernetes.io/instance=ossmplugin"
+  register: ossmplugin_pod
+
+
+- name: Get OSSMPlugin Deployment
+  k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ ossmplugin.install_namespace }}"
+    label_selectors:
+    - "app.kubernetes.io/instance=ossmplugin"
+  register: ossmplugin_deployment

--- a/operator/molecule/common/wait_for_ossmplugin_cr_changes.yml
+++ b/operator/molecule/common/wait_for_ossmplugin_cr_changes.yml
@@ -1,0 +1,15 @@
+- name: Wait for OSSMPlugin CR changes to take effect
+  k8s_info:
+    api_version: kiali.io/v1alpha1
+    kind: OSSMPlugin
+    name: "{{ custom_resource.metadata.name }}"
+    namespace: "{{ cr_namespace }}"
+  register: ossmplugin_cr_list
+  until:
+  - ossmplugin_cr_list is success
+  - ossmplugin_cr_list.resources is defined
+  - ossmplugin_cr_list.resources | length > 0
+  - ossmplugin_cr_list | json_query('resources[*].status.conditions[?message==`Awaiting next reconciliation`].status') | flatten | join == 'True'
+  - ossmplugin_cr_list | json_query('resources[*].status.conditions[?message==`Awaiting next reconciliation`].reason') | flatten | join == 'Successful'
+  retries: "{{ wait_retries }}"
+  delay: 5

--- a/operator/molecule/config-values-test/converge.yml
+++ b/operator/molecule/config-values-test/converge.yml
@@ -1,0 +1,17 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../common/wait_for_ossmplugin_cr_changes.yml
+
+  - set_fact:
+      current_ossmplugin_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: The current Kiali CR to be used as the base of the test
+    debug:
+      msg: "{{ current_ossmplugin_cr }}"

--- a/operator/molecule/config-values-test/molecule.yml
+++ b/operator/molecule/config-values-test/molecule.yml
@@ -1,0 +1,41 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_enabled: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/config-values-test/ossmplugin-cr.yaml"
+        cr_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        ossmplugin:
+          spec_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: istio-system
+          operator_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin-operator' if lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/ossmplugin-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: ossmplugin-operator
+          operator_cluster_role_creator: "true"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: config-values-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/config-values-test/ossmplugin-cr.yaml
+++ b/operator/molecule/config-values-test/ossmplugin-cr.yaml
@@ -1,0 +1,5 @@
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin
+spec:

--- a/operator/molecule/default/cleanup.yml
+++ b/operator/molecule/default/cleanup.yml
@@ -1,0 +1,10 @@
+- name: Cleanup
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+
+  # Cleanup should only ever execute when a molecule test fails
+
+  - import_tasks: dump-logs.yml

--- a/operator/molecule/default/converge.yml
+++ b/operator/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml

--- a/operator/molecule/default/destroy.yml
+++ b/operator/molecule/default/destroy.yml
@@ -1,0 +1,19 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+
+  - name: Remove OSSMPlugin CR
+    vars:
+      custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+    k8s:
+      state: absent
+      api_version: kiali.io/v1alpha1
+      kind: OSSMPlugin
+      namespace: "{{ cr_namespace }}"
+      name: "{{ custom_resource.metadata.name }}"
+      wait: yes
+      wait_timeout: 600
+    ignore_errors: yes

--- a/operator/molecule/default/dump-logs.yml
+++ b/operator/molecule/default/dump-logs.yml
@@ -1,0 +1,39 @@
+# This will dump the server logs and operator logs. Use this mainly for debugging failures.
+# Upon cleanup (which happens on molecule test failures), these tasks should run.
+
+- set_fact:
+    dump_logs_on_error: "{{ lookup('env', 'MOLECULE_DUMP_LOGS_ON_ERROR') | default('true', True) }}"
+
+- name: Get OSSMPlugin Operator Pod logs
+  k8s_log:
+    namespace: "{{ ossmplugin.operator_namespace }}"
+    label_selectors:
+    - app.kubernetes.io/name=ossmplugin-operator
+  register: ossmplugin_operator_logs
+  ignore_errors: yes
+  when:
+  - dump_logs_on_error == True
+
+- name: Dump OSSMPlugin Operator Pod logs
+  debug:
+    msg: "{{ ossmplugin_operator_logs.log_lines }}"
+  when:
+  - dump_logs_on_error == True
+  - ossmplugin_operator_logs is defined and ossmplugin_operator_logs.log_lines is defined
+
+- name: Get OSSMPlugin Pod logs
+  k8s_log:
+    namespace: "{{ ossmplugin.install_namespace }}"
+    label_selectors:
+    - app.kubernetes.io/name=ossmplugin
+  register: ossmplugin_logs
+  ignore_errors: yes
+  when:
+  - dump_logs_on_error == True
+
+- name: Dump OSSMPlugin Pod logs
+  debug:
+    msg: "{{ ossmplugin_logs.log_lines }}"
+  when:
+  - dump_logs_on_error == True
+  - ossmplugin_logs is defined and ossmplugin_logs.log_lines is defined

--- a/operator/molecule/default/molecule.yml
+++ b/operator/molecule/default/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_enabled: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/ossmplugin-cr.yaml"
+        cr_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        ossmplugin:
+          install_namespace: istio-system
+          operator_namespace: "{{ 'openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators' }}"
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin-operator' if lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/ossmplugin-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: ""
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin' if lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME') == 'dev' else ('quay.io/kiali/ossmplugin' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_VERSION') }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: default
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -1,0 +1,49 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+
+  - name: Make sure the operator namespace exists
+    k8s:
+      state: present
+      api_version: v1
+      kind: Namespace
+      name: "{{ ossmplugin.operator_namespace }}"
+
+  - name: Wait for the CRD to be established
+    k8s_info:
+      api_version: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: ossmplugins.kiali.io
+      wait: yes
+      wait_condition:
+        type: Established
+
+  - name: Prepare initial OSSMPlugin CR definition based solely on the template
+    set_fact:
+      ossmplugin_cr_definition: "{{ lookup('template', cr_file_path) }}"
+
+  - name: Create OSSMPlugin CR
+    k8s:
+      namespace: "{{ cr_namespace }}"
+      definition: "{{ ossmplugin_cr_definition }}"
+
+  - name: Asserting that OSSMPlugin is Deployed
+    vars:
+      instance_name: "{{ ossmplugin.instance_name | default('ossmplugin') }}"
+    k8s_info:
+      api_version: v1
+      kind: Deployment
+      namespace: "{{ ossmplugin.install_namespace }}"
+      label_selectors:
+      - "app.kubernetes.io/name=ossmplugin"
+    register: ossmplugin_deployment
+    until:
+    - ossmplugin_deployment is success
+    - ossmplugin_deployment.resources | length == 1
+    - ossmplugin_deployment.resources[0].status.availableReplicas is defined
+    - ossmplugin_deployment.resources[0].status.availableReplicas == 1
+    retries: "{{ wait_retries }}"
+    delay: 5

--- a/operator/molecule/docker/Dockerfile
+++ b/operator/molecule/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/ansible/toolset:3.5.0
+ENV PACKAGES="\
+gettext \
+gcc \
+libc-dev \
+curl \
+bash \
+openssl \
+"
+RUN apt-get update && apt-get install -y ${PACKAGES}
+RUN pip install openshift junit-xml jmespath docker kubernetes
+RUN ansible-galaxy collection install kubernetes.core

--- a/operator/molecule/ossmplugin-cr.yaml
+++ b/operator/molecule/ossmplugin-cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: kiali.io/v1alpha1
+kind: OSSMPlugin
+metadata:
+  name: ossmplugin
+spec:
+  deployment:
+    imageName: "{{ ossmplugin.imageName }}"
+    imagePullPolicy: "{{ ossmplugin.imagePullPolicy }}"
+    imageVersion: "{{ ossmplugin.imageVersion }}"

--- a/operator/molecule/requirements.txt
+++ b/operator/molecule/requirements.txt
@@ -1,0 +1,9 @@
+# Project requirements
+# 'pip install -r requirements.txt'
+# In addition to these, you must also exec "ansible-galaxy collection install kubernetes.core"
+molecule
+openshift
+jmespath
+junit-xml
+kubernetes
+docker

--- a/operator/playbooks/default-playbook.yml
+++ b/operator/playbooks/default-playbook.yml
@@ -1,0 +1,1 @@
+playbook: default

--- a/operator/playbooks/default-supported-images.yml
+++ b/operator/playbooks/default-supported-images.yml
@@ -1,0 +1,2 @@
+default: {"imageName": "quay.io/kiali/servicemesh-plugin", "imageVersion": "operator_version"}
+v0_1:    {"imageName": "quay.io/kiali/servicemesh-plugin", "imageVersion": "v0.1"}

--- a/operator/playbooks/ossmplugin-deploy.yml
+++ b/operator/playbooks/ossmplugin-deploy.yml
@@ -1,0 +1,70 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+  - kubernetes.core
+  tasks:
+
+  - debug:
+      msg: OSSMPLUGIN RECONCILIATION START
+
+  - debug:
+      msg: "CR: name={{ ansible_operator_meta.name }}, namespace={{ ansible_operator_meta.namespace }}"
+
+  - name: Playbook start time
+    set_fact:
+      playbook_time_start: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - name: Determine the default playbook
+    include_vars:
+      file: "default-playbook.yml"
+      name: default_playbook
+
+  - name: Determine the version that is to be installed
+    set_fact:
+      version: "{{ version | default(default_playbook.playbook) }}"
+
+  - name: Determine the default supported images for all known versions
+    include_vars:
+      file: "default-supported-images.yml"
+      name: supported_ossmplugin_images
+
+  - name: Override the supported images if found in the environment
+    set_fact:
+      supported_ossmplugin_images: "{{ supported_ossmplugin_images | default({}) | combine({item.key: {'image_name': lookup('env', 'RELATED_IMAGE_ossmplugin_' + (item.key | replace('.','_'))) | regex_replace('(.+):.+', '\\1'), 'image_version': lookup('env', 'RELATED_IMAGE_ossmplugin_' + (item.key | replace('.','_'))) | regex_replace('.+:(.+)', '\\1')}}, recursive=True) }}"
+    loop: "{{ supported_ossmplugin_images | default({}) | dict2items }}"
+    when:
+    - lookup('env', 'RELATED_IMAGE_ossmplugin_' + (item.key | replace('.','_')))
+
+  - name: Examine environment and determine if supported image for the requested version is overridden even if no default is known
+    vars:
+      supported_image_env: "{{ lookup('env', 'RELATED_IMAGE_ossmplugin_' + (version | replace('.','_'))) }}"
+    set_fact:
+      supported_ossmplugin_images: "{{ supported_ossmplugin_images | default({}) | combine({version: {'image_name': supported_image_env | regex_replace('(.+):.+', '\\1'), 'image_version': supported_image_env | regex_replace('.+:(.+)', '\\1')}}, recursive=True) }}"
+    when:
+    - supported_image_env is defined
+    - supported_image_env != ""
+
+  - name: Make sure a default supported image or an override image is known
+    fail:
+      msg: "Asked to install a version [{{ version }}] that does not have a known supported image."
+    when:
+    - supported_ossmplugin_images[version] is not defined
+
+  - name: Run the version-specific deploy role
+    include_role:
+      name: "{{ version }}/ossmplugin-deploy"
+    when:
+    - skip_reconciliation is not defined or skip_reconciliation == False
+
+  - name: Playbook end time
+    set_fact:
+      playbook_time_end: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - name: Log reconciliation processing time
+    ignore_errors: yes
+    debug:
+      msg: "Processing time: [{{ (playbook_time_end|to_datetime - playbook_time_start|to_datetime).total_seconds() | int }}] seconds"
+
+  - debug:
+      msg: OSSMPLUGIN RECONCILIATION IS DONE.
+

--- a/operator/playbooks/ossmplugin-remove.yml
+++ b/operator/playbooks/ossmplugin-remove.yml
@@ -1,0 +1,42 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+  - kubernetes.core
+  tasks:
+
+  - ignore_errors: yes
+    debug:
+      msg: REMOVING OSSMPLUGIN
+
+  - ignore_errors: yes
+    debug:
+      msg: "CR: name={{ ansible_operator_meta.name }}, namespace={{ ansible_operator_meta.namespace }}"
+
+  - ignore_errors: yes
+    name: Playbook start time
+    set_fact:
+      playbook_time_start: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - ignore_errors: yes
+    name: Determine the default playbook
+    include_vars:
+      file: "default-playbook.yml"
+      name: default_playbook
+
+  - ignore_errors: yes
+    include_role:
+      name: "{{ version | default(default_playbook.playbook) }}/ossmplugin-remove"
+
+  - ignore_errors: yes
+    name: Playbook end time
+    set_fact:
+      playbook_time_end: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - ignore_errors: yes
+    name: Log removal processing time
+    debug:
+      msg: "Processing time: [{{ (playbook_time_end|to_datetime - playbook_time_start|to_datetime).total_seconds() | int }}] seconds"
+
+  - ignore_errors: yes
+    debug:
+      msg: OSSMPLUGIN REMOVAL IS DONE.

--- a/operator/requirements.yml
+++ b/operator/requirements.yml
@@ -1,0 +1,27 @@
+# This is the Ansible Galaxy requirements that need to be installed locally to be able to run
+# the operator Ansible playbook locally.
+#
+# To install these into your local Ansible environment:
+#   ansible-galaxy collection install -r requirements.yml --force-with-deps
+#
+# Make sure these collections match that which is inside the Ansible Operator SDK base image.
+# You can determine what collections are installed by looking in the base image like this:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.9 \
+#   ls /opt/ansible/.ansible/collections/ansible_collections
+#
+# To determine the version of a specific collection, look at the MANIFEST.json:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.9 \
+#   cat /opt/ansible/.ansible/collections/ansible_collections/kubernetes/core/MANIFEST.json | grep version
+
+collections:
+- name: kubernetes.core
+  version: 2.1.1
+- name: operator_sdk.util
+  version: 0.2.0
+

--- a/operator/roles/default/ossmplugin-deploy/defaults/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/defaults/main.yml
@@ -1,0 +1,22 @@
+# Defaults for all user-facing OSSM Plugin settings.
+#
+# Note that these are under the main dictionary group "ossmplugin_defaults".
+# The actual vars used by the role are found in the vars/ directory.
+# These defaults (the dictionaries under "ossmplugin_defaults") are merged into the vars such that the values
+# below (e.g. deployment) are merged in rather than completely replaced by user-supplied values.
+#
+# If new groups are added to these defaults, you must remember to add the merge code to vars/main.yml.
+
+ossmplugin_defaults:
+  version: "default"
+
+  deployment:
+    imageDigest: ""
+    imageName: ""
+    imagePullPolicy: "IfNotPresent"
+    imagePullSecrets: []
+    imageVersion: ""
+    namespace: ""
+
+  kiali:
+    url: ""

--- a/operator/roles/default/ossmplugin-deploy/filter_plugins/stripnone.py
+++ b/operator/roles/default/ossmplugin-deploy/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/operator/roles/default/ossmplugin-deploy/meta/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/operator/roles/default/ossmplugin-deploy/tasks/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/main.yml
@@ -1,0 +1,242 @@
+- set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR as-is
+  set_fact:
+    current_cr: "{{ _kiali_io_ossmplugin }}"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Initializing"
+    status_vars: {}
+
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
+
+- name: Determine the Kubernetes version
+  set_fact:
+    k8s_version: "{{ lookup(k8s_plugin, cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+  ignore_errors: yes
+
+- name: Determine the OpenShift version
+  vars:
+    kube_apiserver_cluster_op_raw: "{{ lookup(k8s_plugin, api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    ri_query: "status.versions[?name == 'raw-internal'].version"
+  set_fact:
+    openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
+
+- name: Determine the Istio implementation
+  set_fact:
+    is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
+
+- name: Get information about the operator
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+    name: "{{ lookup('env', 'POD_NAME') }}"
+  register: operator_pod_raw
+  ignore_errors: yes
+- name: Determine the version of the operator based on the version label
+  set_fact:
+    operator_version: "{{ operator_pod_raw.resources[0].metadata.labels.version }}"
+  when:
+  - operator_pod_raw is defined
+  - operator_pod_raw.resources[0] is defined
+  - operator_pod_raw.resources[0].metadata is defined
+  - operator_pod_raw.resources[0].metadata.labels is defined
+  - operator_pod_raw.resources[0].metadata.labels.version is defined
+- set_fact:
+    operator_version: "unknown"
+  when:
+  - operator_version is not defined
+- debug:
+    msg: "OPERATOR VERSION: [{{ operator_version }}]"
+
+- name: Print some debug information
+  vars:
+    msg: |
+        OSSM Plugin Variables:
+        --------------------------------
+        {{ ossmplugin_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.namespace is not defined or ossmplugin_vars.deployment.namespace == ""
+
+# Never allow deployment.namespace to change to avoid leaking resources - to uninstall resources you must delete the OSSMPlugin CR
+- name: Ensure the deployment.namespace has not changed
+  fail:
+    msg: "The deployment.namespace cannot be changed to a different value. It was [{{ current_cr.status.deployment.namespace }}] but is now [{{ ossmplugin_vars.deployment.namespace }}]. In order to install OSSM Plugin with a different deployment.namespace, please uninstall OSSM Plugin first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.namespace is defined
+  - current_cr.status.deployment.namespace != ossmplugin_vars.deployment.namespace
+
+- set_fact:
+    status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
+  loop: "{{ data[0] | zip(data[1]) | list }}"
+  vars:
+    data:
+    - ['isMaistra', 'kubernetesVersion', 'openshiftVersion', 'operatorVersion']
+    - ["{{is_maistra}}", "{{k8s_version|default('')}}", "{{openshift_version|default('')}}", "{{operator_version}}"]
+  when:
+  - item.1 != ""
+  - item.1 != "false"
+  - item.1 != False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Setting up configuration"
+    status_vars:
+      environment: "{{ status_environment | default({}) }}"
+      deployment:
+        namespace: "{{ ossmplugin_vars.deployment.namespace }}"
+
+- name: Only allow ad-hoc OSSM Plugin image when appropriate
+  fail:
+    msg: "The operator is forbidden from accepting a OSSM Plugin CR that defines an ad hoc OSSM Plugin image [{{ ossmplugin_vars.deployment.imageName }}{{ '@' + ossmplugin_vars.deployment.imageDigest if ossmplugin_vars.deployment.imageDigest != '' else '' }}:{{ ossmplugin_vars.deployment.imageVersion }}]. Remove spec.deployment.imageName, spec.deployment.imageVersion, and spec.deployment.imageDigest from the OSSM Plugin CR."
+  when:
+  - ossmplugin_vars.deployment.imageName != "" or ossmplugin_vars.deployment.imageVersion != "" or ossmplugin_vars.deployment.imageDigest != ""
+  - lookup('env', 'ALLOW_AD_HOC_OSSMPLUGIN_IMAGE') | default('false', True) != "true"
+
+- name: Default the image name to a known supported image.
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'imageName': supported_ossmplugin_images[ossmplugin_vars.version].imageName}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.imageName == ""
+- name: Default the image version to a known supported image.
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'imageVersion': ('latest' if operator_version == 'master' else operator_version) if supported_ossmplugin_images[ossmplugin_vars.version].imageVersion == 'operator_version' else supported_ossmplugin_images[ossmplugin_vars.version].imageVersion}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.imageVersion == ""
+
+- name: If image version is latest then we will want to always pull
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'imagePullPolicy': 'Always'}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "latest"
+
+- name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
+  uri:
+    url: https://api.github.com/repos/kiali/openshift-servicemesh-plugin/releases
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "lastrelease"
+- name: Determine image version when last release is to be installed
+  shell: echo -n $(curl -s https://api.github.com/repos/kiali/openshift-servicemesh-plugin/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)
+  register: github_lastrelease
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "lastrelease"
+- set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'imageVersion': github_lastrelease.stdout}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "lastrelease"
+
+- name: Determine image version when it explicitly was configured as the operator_version
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'imageVersion': 'latest' if operator_version == 'master' else operator_version}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "operator_version"
+
+- fail:
+    msg: "Could not determine what the image version should be. Set deployment.imageVersion to a valid value"
+  when:
+  - ossmplugin_vars.deployment.imageVersion == "" or ossmplugin_vars.deployment.imageVersion == "unknown"
+
+# Indicate which image we are going to use.
+- debug:
+    msg: "IMAGE_NAME={{ ossmplugin_vars.deployment.imageName }}; IMAGE VERSION={{ ossmplugin_vars.deployment.imageVersion }}"
+
+- name: Determine what metadata labels to apply to all created resources
+  set_fact:
+    ossmplugin_resource_metadata_labels:
+      app: ossmplugin
+      version: "{{ ossmplugin_vars.deployment.imageVersion }}"
+      app.kubernetes.io/name: ossmplugin
+      app.kubernetes.io/version: "{{ ossmplugin_vars.deployment.imageVersion }}"
+      app.kubernetes.io/instance: ossmplugin
+      app.kubernetes.io/part-of: ossmplugin
+
+- name: Delete OSSM Plugin deployment if image is changing - this uninstalled any old version of OSSM Plugin that might be running
+  k8s:
+    state: absent
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ ossmplugin_vars.deployment.namespace }}"
+    name: ossmplugin
+  when:
+  - current_image_name is defined and current_image_version is defined
+  - (current_image_name != ossmplugin_vars.deployment.imageName) or (current_image_version != ossmplugin_vars.deployment.imageVersion)
+
+# Get the deployment's custom annotation we set that tells us when we last updated the Deployment.
+# We need this to ensure the Deployment we update retains this same timestamp unless changes are made
+# that requires a pod restart - in which case we update this timestamp.
+- name: Find current deployment, if it exists
+  set_fact:
+    current_deployment: "{{ lookup(k8s_plugin, resource_name='ossmplugin', namespace=ossmplugin_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+
+- name: Get current deployment last-updated annotation timestamp from existing deployment
+  set_fact:
+    current_deployment_last_updated: "{{ current_deployment.spec.template.metadata.annotations['ossmplugin.kiali.io/last-updated'] if current_deployment.spec.template.metadata.annotations['ossmplugin.kiali.io/last-updated'] is defined else lookup('pipe','date') }}"
+    deployment_is_new: false
+  when:
+  - current_deployment is defined
+  - current_deployment.spec is defined
+  - current_deployment.spec.template is defined
+  - current_deployment.spec.template.metadata is defined
+  - current_deployment.spec.template.metadata.annotations is defined
+
+- name: Set current deployment last-updated annotation timestamp for new deployments
+  set_fact:
+    current_deployment_last_updated: "{{ lookup('pipe','date') }}"
+    deployment_is_new: true
+  when:
+  - current_deployment_last_updated is not defined
+
+# Now deploy all resources for the specific cluster environment
+
+- name: Execute for OpenShift environment
+  include: openshift/os-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+
+# If something changed that can only be picked up when the OSSM Plugin pod starts up, then restart the pod using a rolling restart
+- name: Force the OSSM Plugin pod to restart if necessary
+  vars:
+    updated_deployment: "{{ lookup(k8s_plugin, resource_name='ossmplugin', namespace=ossmplugin_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'ossmplugin.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+  k8s:
+    state: "present"
+    definition: "{{ updated_deployment }}"
+  when:
+  - deployment_is_new == False
+  - processed_resources.configmap is defined
+  - processed_resources.configmap.changed == True
+  - processed_resources.configmap.method == "patch"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Enabling plugin"
+    status_vars: {}
+
+- name: Enable plugin by ensuring the OSSM Plugin is in the Console list of plugins
+  vars:
+    existing_plugins: "{{ lookup('kubernetes.core.k8s', resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console').spec.plugins | default([]) }}"
+  k8s:
+    state: patched
+    api_version: operator.openshift.io/v1
+    kind: Console
+    name: cluster
+    definition:
+      spec:
+        plugins: "{{ (existing_plugins | difference(['servicemesh'])) + ['servicemesh'] }}"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Finished"
+    status_vars: {}

--- a/operator/roles/default/ossmplugin-deploy/tasks/openshift/os-main.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/openshift/os-main.yml
@@ -1,0 +1,17 @@
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating core resources"
+
+- name: Create OSSM Plugin objects on OpenShift
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "openshift"
+    role_namespaces: "{{ [ ossmplugin_vars.deployment.namespace ] }}"
+  loop:
+  - configmap-nginx
+  - configmap-plugin
+  - deployment
+  - service
+  - consoleplugin
+  loop_control:
+    loop_var: process_resource_item

--- a/operator/roles/default/ossmplugin-deploy/tasks/process-resource.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/process-resource.yml
@@ -1,0 +1,15 @@
+- name: "Create resource [{{ process_resource_item }}] on [{{ process_resource_cluster }}]"
+  k8s:
+    state: "present"
+    definition: "{{ lookup('template', 'templates/' + process_resource_cluster + '/' + process_resource_item + '.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+  delay: 10
+
+# Store the results of the processed resource so they can be examined later (e.g. to know if something changed or stayed the same)
+- set_fact:
+    processed_resources: "{{ processed_resources | default({}) | combine( { process_resource_item: { 'changed': process_resource_result.changed, 'method': process_resource_result.method } } ) }}"

--- a/operator/roles/default/ossmplugin-deploy/tasks/update-status-progress.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/update-status-progress.yml
@@ -1,0 +1,16 @@
+- name: Prepare status progress facts
+  ignore_errors: yes
+  set_fact:
+    status_progress_step: "{{ 1 if status_progress_step is not defined else (status_progress_step|int + 1) }}"
+    status_progress_start: "{{ ('%Y-%m-%d %H:%M:%S' | strftime) if status_progress_start is not defined else (status_progress_start) }}"
+
+- name: Update CR status progress field with any additional status fields
+  ignore_errors: yes
+  vars:
+    duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"

--- a/operator/roles/default/ossmplugin-deploy/tasks/update-status.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/update-status.yml
@@ -1,0 +1,8 @@
+- name: Update CR status field
+  ignore_errors: yes
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars }}"

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-nginx.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-nginx.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: {{ ossmplugin_vars.deployment.namespace }}
+  labels: {{ ossmplugin_resource_metadata_labels }}
+data:
+  nginx.conf: |
+    error_log /dev/stdout info;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              9443 ssl;
+        ssl_certificate     /var/serving-cert/tls.crt;
+        ssl_certificate_key /var/serving-cert/tls.key;
+        location / {
+          root                /usr/share/nginx/html;
+        }
+      }
+    }

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-plugin.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-plugin.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-conf
+  namespace: {{ ossmplugin_vars.deployment.namespace }}
+  labels: {{ ossmplugin_resource_metadata_labels }}
+data:
+  plugin-config.json: |
+    {
+      "kialiUrl": "{{ ossmplugin_vars.kiali.url }}"
+    }

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/consoleplugin.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/consoleplugin.yaml
@@ -1,0 +1,11 @@
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: servicemesh
+spec:
+  displayName: "OpenShift Service Mesh Plugin"
+  service:
+    name: ossmplugin
+    namespace: ossmplugin
+    port: 9443
+    basePath: "/"

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/deployment.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ossmplugin
+  namespace: {{ ossmplugin_vars.deployment.namespace }}
+  labels: {{ ossmplugin_resource_metadata_labels }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ossmplugin
+      app.kubernetes.io/instance: ossmplugin
+  template:
+    metadata:
+      name: ossmplugin
+      labels: {{ ossmplugin_resource_metadata_labels }}
+      annotations:
+        ossmplugin.kiali.io/last-updated: "{{ deployment_last_updated }}"
+    spec:
+{% if ossmplugin_vars.deployment.imagePullSecrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in ossmplugin_vars.deployment.imagePullSecrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+      containers:
+      - name: ossmplugin
+        image: {{ ossmplugin_vars.deployment.imageName }}{{ '@' + ossmplugin_vars.deployment.imageDigest if ossmplugin_vars.deployment.imageDigest != '' else '' }}:{{ ossmplugin_vars.deployment.imageVersion }}
+        imagePullPolicy: {{ ossmplugin_vars.deployment.imagePullPolicy }}
+        ports:
+        - containerPort: 9443
+          protocol: TCP
+        volumeMounts:
+        - name: ossmplugin-cert-secret
+          readOnly: true
+          mountPath: /var/serving-cert
+        - name: nginx-conf
+          readOnly: true
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: plugin-conf
+          readOnly: true
+          mountPath: /usr/share/nginx/html/plugin-config.json
+          subPath: plugin-config.json
+      volumes:
+      - name: ossmplugin-cert-secret
+        secret:
+          secretName: ossmplugin-cert-secret
+          defaultMode: 420
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          defaultMode: 420
+      - name: plugin-conf
+        configMap:
+          name: plugin-conf
+          defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+      maxSurge: "25%"

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/service.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ossmplugin
+  namespace: {{ ossmplugin_vars.deployment.namespace }}
+  labels: {{ ossmplugin_resource_metadata_labels }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ossmplugin-cert-secret
+spec:
+  ports:
+  - name: 9443-tcp
+    protocol: TCP
+    port: 9443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: ossmplugin
+    app.kubernetes.io/instance: ossmplugin
+  type: ClusterIP
+  sessionAffinity: None

--- a/operator/roles/default/ossmplugin-deploy/vars/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/vars/main.yml
@@ -1,0 +1,30 @@
+# These are the actual variables used by the role. You will notice it is
+# one big dictionary (key="ossmplugin_vars") whose child dictionaries mimic those
+# as defined in defaults/main.yml.
+# The child dictionaries below will have values that are a combination of the default values
+# (as found in defaults/main.yaml) and user-supplied values.
+# Without this magic, a user supplying only one key/value pair in a child dictionary will
+# clear out (make undefined) all the rest of the key/value pairs in that child dictionary.
+# This is not what we want. We want the rest of the dictionary to keep the defaults,
+# thus allowing the user to override only a subset of key/values in a dictionary.
+#
+# I found this trick at https://groups.google.com/forum/#!topic/Ansible-project/pGbRYZyqxZ4
+# I tweeked that solution a little bit because I did not want to require the user to supply
+# everything under a main "ossmplugin_vars" dictionary.
+
+ossmplugin_vars:
+  version: "{{ version | default(ossmplugin_defaults.version) }}"
+
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ ossmplugin_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmplugin_defaults.deployment }}
+    {%- endif -%}
+
+  kiali: |
+    {%- if kiali is defined and kiali is iterable -%}
+    {{ ossmplugin_defaults.kiali | combine((kiali | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmplugin_defaults.kiali }}
+    {%- endif -%}

--- a/operator/roles/default/ossmplugin-remove/defaults/main.yml
+++ b/operator/roles/default/ossmplugin-remove/defaults/main.yml
@@ -1,0 +1,3 @@
+ossmplugin_defaults:
+  deployment:
+    namespace: ""

--- a/operator/roles/default/ossmplugin-remove/filter_plugins/stripnone.py
+++ b/operator/roles/default/ossmplugin-remove/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/operator/roles/default/ossmplugin-remove/meta/main.yml
+++ b/operator/roles/default/ossmplugin-remove/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/operator/roles/default/ossmplugin-remove/tasks/main.yml
+++ b/operator/roles/default/ossmplugin-remove/tasks/main.yml
@@ -1,0 +1,72 @@
+# These tasks remove all resources such that no remnants of OSSM Plugin will remain.
+#
+# Note that we ignore_errors everywhere - we do not want these tasks to ever abort with a failure.
+# This is because these are run within a finalizer and if a failure aborts any task here
+# the user will never be able to delete the OSSMPlugin CR - in fact, the delete will hang indefinitely
+# and the user will need to do an ugly hack to fix it.
+
+- ignore_errors: yes
+  set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR that was deleted
+  ignore_errors: yes
+  set_fact:
+    current_cr: "{{ _kiali_io_ossmplugin }}"
+
+- name: Print some debug information
+  ignore_errors: yes
+  vars:
+    msg: |
+        OSSMPlugin Variables:
+        --------------------------------
+        {{ ossmplugin_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  ignore_errors: yes
+  set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.deployment.namespace is not defined or ossmplugin_vars.deployment.namespace == ""
+
+- name: Disable plugin by ensuring the OSSM Plugin is removed from the Console list of plugins
+  ignore_errors: yes
+  vars:
+    existing_plugins: "{{ lookup('kubernetes.core.k8s', resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console').spec.plugins | default([]) }}"
+  k8s:
+    state: patched
+    api_version: operator.openshift.io/v1
+    kind: Console
+    name: cluster
+    definition:
+      spec:
+        plugins: "{{ existing_plugins | difference(['servicemesh']) }}"
+
+- name: Delete OSSMPlugin resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ ossmplugin_vars.deployment.namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query(k8s_plugin, namespace=ossmplugin_vars.deployment.namespace, kind='ConfigMap',      resource_name='nginx-config',  api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=ossmplugin_vars.deployment.namespace, kind='ConfigMap',      resource_name='plugin-config', api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=ossmplugin_vars.deployment.namespace, kind='Deployment',     resource_name='ossmplugin',    api_version='apps/v1') }}"
+  - "{{ query(k8s_plugin, namespace=ossmplugin_vars.deployment.namespace, kind='Service',        resource_name='ossmplugin',    api_version='v1') }}"
+  - "{{ query(k8s_plugin, kind='ConsolePlugin', resource_name='servicemesh', api_version='console.openshift.io/v1alpha1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/operator/roles/default/ossmplugin-remove/vars/main.yml
+++ b/operator/roles/default/ossmplugin-remove/vars/main.yml
@@ -1,0 +1,7 @@
+ossmplugin_vars:
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ ossmplugin_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmplugin_defaults.deployment }}
+    {%- endif -%}

--- a/operator/watches.yaml
+++ b/operator/watches.yaml
@@ -1,0 +1,12 @@
+---
+- version: v1alpha1
+  group: kiali.io
+  kind: OSSMPlugin
+  playbook: playbooks/ossmplugin-deploy.yml
+  reconcilePeriod: "0s"
+  watchDependentResources: False
+  watchClusterScopedResources: False
+  snakeCaseParameters: False
+  finalizer:
+    name: kiali.io/finalizer
+    playbook: playbooks/ossmplugin-remove.yml


### PR DESCRIPTION
This introduces the OSSM Plugin operator.

Note that I moved the plugin make targets to make/Makefile.plugin.mk, but they all work as before. So nothing changes from the user-perspective (e.g. `make build-plugin build-plugin-image` still works as does `make deploy-plugin enable-plugin`). I also added a `make undeploy-plugin`.

Do a `make help` to see all the make targets available.