### PR TITLE
operator will auto-discover kiali route if kiali.url not specified in CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ include make/Makefile.plugin.mk
 include make/Makefile.operator.mk
 include make/Makefile.cluster.mk
 include make/Makefile.olm.mk
+include make/Makefile.molecule.mk
 
 help:
 	@echo
@@ -40,6 +41,9 @@ help:
 	@echo
 	@echo "OLM targets - used to deploy the operator via OLM"
 	@sed -n 's/^##//p' make/Makefile.olm.mk | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+	@echo "Molecule targets - used to run the operator molecule tests"
+	@sed -n 's/^##//p' make/Makefile.molecule.mk | column -t -s ':' |  sed -e 's/^/ /'
 	@echo
 
 .ensure-oc-exists:

--- a/make/Makefile.molecule.mk
+++ b/make/Makefile.molecule.mk
@@ -1,0 +1,105 @@
+#
+# Targets to run operator molecule tests.
+# The molecule tests expect an operator to already be installed. Use "make operator-create" as one way to do this.
+#
+
+# The test scenario(s) to run - see molecule/ - all directories with a name *-test are scenarios you can run
+# To run multiple scenarios sequentially, specify a space-separated list: make -e MOLECULE_SCENARIO="first-test second-test" molecule-test
+MOLECULE_SCENARIO ?= default
+
+# Defines what playbook version to test. This is the value to put in the tests' OSSMPlugin CR spec.version field.
+MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION ?= default
+
+# Set MOLECULE_USE_DEV_IMAGES to true to use your local OSSM Plugin dev builds (not released images from quay.io).
+# To use this, you must have first pushed your local dev builds via the cluster-push targets.
+#
+# If MOLECULE_USE_DEV_IMAGES is not set or set to 'false', that usually means you want to pick up the latest images
+# published on quay.io. However, if you want to test the default plugin image that the operator will install, you
+# can set MOLECULE_USE_DEFAULT_OSSMPLUGIN_IMAGE=true. When that is set (in conjunction with MOLECULE_USE_DEV_IMAGES=false),
+# the molecule tests will set the spec.deployment.imageVersion and spec.deployment.imageName override fields to an
+# empty string thus causing the plugin image to be the default image installed by the operator. This is useful
+# when you are installing via OLM and you want to test with a specific CR spec.version (MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION)
+# and the default plugin that is installed by the operator for that spec.version.
+#
+# Note that you can override everything mentioned above in order to use your own image names/versions. You can do this by
+# setting MOLECULE_IMAGE_ENV_ARGS. This is useful if you want to test a specific released version or images found in a different repo.
+# If the x_IMAGE_NAME env vars are set to 'dev' then the molecule tests will use the internal OpenShift registry location.
+# An example MOLECULE_IMAGE_ENV_ARGS can be:
+#
+#   MOLECULE_IMAGE_ENV_ARGS = --env MOLECULE_OSSMPLUGIN_IMAGE_NAME=quay.io/myuser/kiali \
+#                             --env MOLECULE_OSSMPLUGIN_IMAGE_VERSION=test
+
+ifndef MOLECULE_IMAGE_ENV_ARGS
+ifeq ($(MOLECULE_USE_DEV_IMAGES),true)
+MOLECULE_IMAGE_ENV_ARGS = --env MOLECULE_OSSMPLUGIN_IMAGE_NAME=dev --env MOLECULE_OSSMPLUGIN_IMAGE_VERSION=dev
+else ifeq ($(MOLECULE_USE_DEFAULT_OSSMPLUGIN_IMAGE),true)
+MOLECULE_IMAGE_ENV_ARGS = --env 'MOLECULE_OSSMPLUGIN_IMAGE_NAME=' --env 'MOLECULE_OSSMPLUGIN_IMAGE_VERSION='
+endif
+endif
+
+ifeq ($(MOLECULE_DEBUG),true)
+MOLECULE_DEBUG_ARG = --debug
+endif
+
+ifeq ($(MOLECULE_DESTROY_NEVER),true)
+MOLECULE_DESTROY_NEVER_ARG = --destroy never
+endif
+
+# If turned on, the operator and plugin pod logs are dumped in the molecule logs if a molecule test fails
+ifdef MOLECULE_DUMP_LOGS_ON_ERROR
+MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR ?= --env MOLECULE_DUMP_LOGS_ON_ERROR=${MOLECULE_DUMP_LOGS_ON_ERROR}
+else
+MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR ?= --env MOLECULE_DUMP_LOGS_ON_ERROR=true
+endif
+
+# Turns on or off the ansible profiler which dumps profile logs after each operator reconciliation run
+ifdef MOLECULE_OPERATOR_PROFILER_ENABLED
+MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR ?= --env MOLECULE_OPERATOR_PROFILER_ENABLED=${MOLECULE_OPERATOR_PROFILER_ENABLED}
+else
+MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR ?= --env MOLECULE_OPERATOR_PROFILER_ENABLED=true
+endif
+
+MOLECULE_KUBECONFIG ?= ${HOME}/.kube/config
+
+# Only allocate a pseudo-TTY if there is a terminal attached - this enables more readable colored text in ansible output.
+# But do not set this option if there is not TERM (i.e. when run within a cron job) to avoid a runtime failure.
+ifdef TERM
+MOLECULE_DOCKER_TERM_ARGS=-t
+endif
+
+# We need to perform many retries when on OpenShift particularly when running on slower machines
+MOLECULE_WAIT_RETRIES ?= 360
+MOLECULE_WAIT_RETRIES_ARG ?= --env MOLECULE_WAIT_RETRIES=${MOLECULE_WAIT_RETRIES}
+
+.prepare-force-molecule-build:
+	@$(eval FORCE_MOLECULE_BUILD ?= $(shell ${DORP} inspect kiali-molecule:latest > /dev/null 2>&1 || echo "true"))
+
+## molecule-build: Builds an image to run Molecule without requiring the host to have python/pip installed. If it already exists, and you want to build it again, set env var FORCE_MOLECULE_BUILD to "true".
+molecule-build: .prepare-force-molecule-build
+	@if [ "${FORCE_MOLECULE_BUILD}" == "true" ]; then ${DORP} build --no-cache -t kiali-molecule:latest ${OPERATOR_DIR}/molecule/docker; else echo "Will not rebuild kiali-molecule image."; fi
+
+ifndef MOLECULE_ADD_HOST_ARGS
+.prepare-add-host-args: .prepare-cluster
+	@echo "Will auto-detect hosts to add based on the CLUSTER_REPO: ${CLUSTER_REPO}"
+	@$(eval MOLECULE_ADD_HOST_ARGS ?= $(shell basehost="$(shell echo ${CLUSTER_REPO} | sed 's/^.*\.apps\.\(.*\)/\1/')"; kialihost="kiali-istio-system.apps.$${basehost}"; kialiip="$$(getent hosts $${kialihost} | head -n 1 | awk '{ print $$1 }')"; prometheushost="prometheus-istio-system.apps.$${basehost}"; prometheusip="$$(getent hosts $${prometheushost} | head -n 1 | awk '{ print $$1 }')" apihost="api.$${basehost}"; apiip="$$(getent hosts $${apihost} | head -n 1 | awk '{ print $$1 }')"; oauthoshost="oauth-openshift.apps.$${basehost}"; oauthosip="$$(getent hosts $${oauthoshost} | head -n 1 | awk '{ print $$1 }')"; echo "--add-host=$$kialihost:$$kialiip --add-host=$$prometheushost:$$prometheusip --add-host=$$apihost:$$apiip --add-host=$$oauthoshost:$$oauthosip"))
+	@echo "Auto-detected add host args: ${MOLECULE_ADD_HOST_ARGS}"
+else
+.prepare-add-host-args:
+	@echo "Will use the given add host args: ${MOLECULE_ADD_HOST_ARGS}"
+endif
+
+.prepare-molecule-data-volume:
+	$(DORP) volume create molecule-tests-volume
+	$(DORP) create -v molecule-tests-volume:/data --name molecule-volume-helper docker.io/busybox true
+	$(DORP) cp "${OPERATOR_DIR}" molecule-volume-helper:/data/operator
+	$(DORP) cp "${MOLECULE_KUBECONFIG}" molecule-volume-helper:/data/kubeconfig
+	$(DORP) rm molecule-volume-helper
+
+## molecule-test: Runs Molecule tests using the Molecule docker image
+molecule-test: .prepare-add-host-args molecule-build .prepare-molecule-data-volume .create-operator-pull-secret
+ifeq ($(DORP),docker)
+	for msn in ${MOLECULE_SCENARIO}; do ${DORP} run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" -v molecule-tests-volume:/tmp/molecule -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=${DORP} --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION=${MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_WAIT_RETRIES_ARG} -v /var/run/docker.sock:/var/run/docker.sock kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; ${DORP} volume rm molecule-tests-volume; exit 1; fi; done
+else
+	for msn in ${MOLECULE_SCENARIO}; do ${DORP} run --rm ${MOLECULE_DOCKER_TERM_ARGS} --env KUBECONFIG="/tmp/molecule/kubeconfig" --env K8S_AUTH_KUBECONFIG="/tmp/molecule/kubeconfig" -v molecule-tests-volume:/tmp/molecule -w /tmp/molecule/operator --network="host" ${MOLECULE_ADD_HOST_ARGS} --add-host="api.crc.testing:192.168.130.11" --add-host="kiali-istio-system.apps-crc.testing:192.168.130.11" --add-host="prometheus-istio-system.apps-crc.testing:192.168.130.11" --env DORP=${DORP} --env OPERATOR_IMAGE_PULL_SECRET_NAME=${OPERATOR_IMAGE_PULL_SECRET_NAME} --env MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION=${MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION} ${MOLECULE_IMAGE_ENV_ARGS} ${MOLECULE_OPERATOR_PROFILER_ENABLED_ENV_VAR} ${MOLECULE_DUMP_LOGS_ON_ERROR_ENV_VAR} ${MOLECULE_WAIT_RETRIES_ARG}                                    localhost/kiali-molecule:latest molecule ${MOLECULE_DEBUG_ARG} test ${MOLECULE_DESTROY_NEVER_ARG} --scenario-name $${msn}; if [ "$$?" != "0" ]; then echo "Molecule test failed: $${msn}"; ${DORP} volume rm molecule-tests-volume; exit 1; fi; done
+endif
+	$(DORP) volume rm molecule-tests-volume

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -105,15 +105,10 @@ uninstall-crd: purge-all-crs
 
 ## install-cr: Installs a test OSSM Plugin CR into the cluster.
 install-cr: create-test-namespace
-	@kiali_route="$$(${OC} get routes -l app.kubernetes.io/name=kiali --all-namespaces -o jsonpath='{.items[0].spec.host}' 2> /dev/null)" ;\
-	if [ -n "$${kiali_route}" ]; then \
-		echo -n "Waiting for the CRD to be established..." ;\
-		while ! ${OC} get crd ossmplugins.kiali.io &> /dev/null ; do echo -n '.'; sleep 1; done ;\
-		${OC} wait --for condition=established --timeout=60s crd ossmplugins.kiali.io ;\
-		cat "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml" | KIALI_URL="https://$${kiali_route}" envsubst | ${OC} apply -f - ;\
-	else \
-		echo "Could not find the Kiali route URL. You need to install Kiali first." && exit 1 ;\
-	fi
+	echo -n "Waiting for the CRD to be established..." ;\
+	while ! ${OC} get crd ossmplugins.kiali.io &> /dev/null ; do echo -n '.'; sleep 1; done ;\
+	${OC} wait --for condition=established --timeout=60s crd ossmplugins.kiali.io ;\
+	cat "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml" | envsubst | ${OC} apply -f - ;\
 
 ## uninstall-cr: Deletes the test OSSM Plugin CR from the cluster and waits for the operator to finalize the deletion.
 uninstall-cr:

--- a/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
+++ b/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
@@ -21,7 +21,7 @@ spec:
         type: object
         properties:
           status:
-            description: "The processing status of this CR as reported by the operator."
+            description: "The processing status of this CR as reported by the OpenShift Service Mesh Plugin Operator."
             type: object
             x-kubernetes-preserve-unknown-fields: true
           spec:
@@ -86,5 +86,5 @@ spec:
                 type: object
                 properties:
                   url:
-                    description: "The main Kiali endpoint URL that the OSSM Plugin will use to communicate with Kiali."
+                    description: "The main Kiali endpoint URL that the OSSM Plugin will use to communicate with Kiali. If empty, an attempt will be made to auto-discover it. If Kiali is installed in the same namespace as the CR, it will take precedence over any other Kiali installation. Otherwise, the first Kiali route found in the cluster will be used."
                     type: string

--- a/operator/deploy/ossmplugin-cr-dev.yaml
+++ b/operator/deploy/ossmplugin-cr-dev.yaml
@@ -11,4 +11,4 @@ spec:
     imageName: quay.io/kiali/servicemesh-plugin
     imageVersion: latest
   kiali:
-    url: ${KIALI_URL}
+    url: ""

--- a/operator/dev-playbook-config/dev-hosts.yaml
+++ b/operator/dev-playbook-config/dev-hosts.yaml
@@ -9,7 +9,7 @@ all:
       imageVersion: dev
 
     kiali:
-      url: https://kiali-istio-system.apps-crc.testing
+      url: ""
 
     # The Operator SDK creates a "ansible_operator_meta" variable
     # that contains the name and namespace of the CR.

--- a/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
+++ b/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
@@ -23,4 +23,4 @@ spec:
     imageVersion: dev
 
   kiali:
-    url: https://kiali-istio-system.apps-crc.testing
+    url: ""

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
@@ -241,4 +241,10 @@ spec:
           - clusteroperators
           verbs:
           - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
         serviceAccountName: ossmplugin-operator

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
@@ -251,4 +251,10 @@ spec:
           - clusteroperators
           verbs:
           - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
         serviceAccountName: ossmplugin-operator

--- a/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
@@ -241,4 +241,10 @@ spec:
           - clusteroperators
           verbs:
           - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
         serviceAccountName: ossmplugin-operator

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -4,27 +4,9 @@
 - name: Determine the cluster type
   set_fact:
     is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
-    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
-    is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
-    is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
 - name: Determine the Istio implementation
   set_fact:
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
-
-- name: Get SMCP if running in Maistra environment
-  k8s_info:
-    api_version: maistra.io/v2
-    kind: ServiceMeshControlPlane
-    namespace: "{{ istio.control_plane_namespace }}"
-  register: maistra_smcp
-  when:
-  - is_maistra == True
-
-- name: There must one and only one SMCP already installed in the control plane
-  set_fact:
-    maistra_smcp: "{{ maistra_smcp.resources[0] }}"
-  when:
-  - is_maistra == True
 
 - name: Get OSSMPlugin CR if present
   set_fact:
@@ -45,9 +27,8 @@
     kind: Pod
     namespace: "{{ ossmplugin.install_namespace }}"
     label_selectors:
-    - "app.kubernetes.io/instance=ossmplugin"
+    - "app.kubernetes.io/name=ossmplugin"
   register: ossmplugin_pod
-
 
 - name: Get OSSMPlugin Deployment
   k8s_info:
@@ -55,5 +36,15 @@
     kind: Deployment
     namespace: "{{ ossmplugin.install_namespace }}"
     label_selectors:
-    - "app.kubernetes.io/instance=ossmplugin"
+    - "app.kubernetes.io/name=ossmplugin"
   register: ossmplugin_deployment
+
+- name: Get OSSMPlugin ConfigMap
+  set_fact:
+    ossmplugin_configmap_resource: "{{ lookup('kubernetes.core.k8s', api_version='v1', kind='ConfigMap', namespace=ossmplugin.install_namespace, resource_name='plugin-conf') }}"
+- name: Format OSSMPlugin ConfigMap
+  set_fact:
+    ossmplugin_configmap: "{{ ossmplugin_configmap_resource.data['plugin-config.json'] | from_json }}"
+- name: Dump OSSMPlugin ConfigMap
+  debug:
+    msg: "{{ ossmplugin_configmap }}"

--- a/operator/molecule/config-values-test/converge.yml
+++ b/operator/molecule/config-values-test/converge.yml
@@ -10,8 +10,12 @@
   - import_tasks: ../common/wait_for_ossmplugin_cr_changes.yml
 
   - set_fact:
-      current_ossmplugin_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+      current_ossmplugin_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMPlugin', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
 
-  - name: The current Kiali CR to be used as the base of the test
+  - name: The current CR to be used as the base of the test
     debug:
       msg: "{{ current_ossmplugin_cr }}"
+
+  - name: Confirm the Kiali URL is as expected
+    assert:
+      that: "{{ ossmplugin_configmap.kialiUrl == current_ossmplugin_cr.status.kiali.url }}"

--- a/operator/molecule/config-values-test/molecule.yml
+++ b/operator/molecule/config-values-test/molecule.yml
@@ -19,20 +19,15 @@ provisioner:
   inventory:
     group_vars:
       all:
-        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/config-values-test/ossmplugin-cr.yaml"
-        cr_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/ossmplugin-cr.yaml"
+        cr_namespace: "{{ 'ossmplugin' }}"
         wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
-        istio:
-          control_plane_namespace: istio-system
         ossmplugin:
           spec_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION') | default('default', True) }}"
-          install_namespace: istio-system
-          operator_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
-          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin-operator' if lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/ossmplugin-operator', True)) }}"
-          operator_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
-          operator_watch_namespace: ossmplugin-operator
-          operator_cluster_role_creator: "true"
-          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          install_namespace: "ossmplugin"
+          operator_namespace: "{{ 'openshift-operators' }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/servicemesh-plugin' if lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME') == 'dev' else ('quay.io/kiali/servicemesh-plugin' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_VERSION') }}"
 scenario:
   name: config-values-test
   test_sequence:

--- a/operator/molecule/config-values-test/ossmplugin-cr.yaml
+++ b/operator/molecule/config-values-test/ossmplugin-cr.yaml
@@ -1,5 +1,0 @@
-apiVersion: kiali.io/v1alpha1
-kind: OSSMPlugin
-metadata:
-  name: ossmplugin
-spec:

--- a/operator/molecule/default/molecule.yml
+++ b/operator/molecule/default/molecule.yml
@@ -20,20 +20,14 @@ provisioner:
     group_vars:
       all:
         cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/ossmplugin-cr.yaml"
-        cr_namespace: "{{ 'ossmplugin-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        cr_namespace: "{{ 'ossmplugin' }}"
         wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
-        istio:
-          control_plane_namespace: istio-system
         ossmplugin:
-          install_namespace: istio-system
-          operator_namespace: "{{ 'openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators' }}"
-          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin-operator' if lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/ossmplugin-operator', True)) }}"
-          operator_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
-          operator_watch_namespace: ""
-          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmplugin' if lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME') == 'dev' else ('quay.io/kiali/ossmplugin' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME')) }}"
+          spec_version: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: "ossmplugin"
+          operator_namespace: "{{ 'openshift-operators' }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/servicemesh-plugin' if lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME') == 'dev' else ('quay.io/kiali/servicemesh-plugin' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_NAME')) }}"
           image_version: "{{ 'latest' if ansible_env.MOLECULE_OSSMPLUGIN_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_VERSION') }}"
-          image_pull_policy: "{{ lookup('env', 'MOLECULE_OSSMPLUGIN_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:
   name: default
   test_sequence:

--- a/operator/molecule/default/prepare.yml
+++ b/operator/molecule/default/prepare.yml
@@ -5,12 +5,21 @@
   - kubernetes.core
   tasks:
 
-  - name: Make sure the operator namespace exists
+  - name: Make sure the cr namespace exists
     k8s:
       state: present
       api_version: v1
       kind: Namespace
-      name: "{{ ossmplugin.operator_namespace }}"
+      name: "{{ cr_namespace }}"
+
+  - name: Make sure the install namespace exists
+    k8s:
+      state: present
+      api_version: v1
+      kind: Namespace
+      name: "{{ ossmplugin.install_namespace }}"
+    when:
+    - ossmplugin.install_namespace != cr_namespace
 
   - name: Wait for the CRD to be established
     k8s_info:
@@ -31,8 +40,6 @@
       definition: "{{ ossmplugin_cr_definition }}"
 
   - name: Asserting that OSSMPlugin is Deployed
-    vars:
-      instance_name: "{{ ossmplugin.instance_name | default('ossmplugin') }}"
     k8s_info:
       api_version: v1
       kind: Deployment

--- a/operator/molecule/ossmplugin-cr.yaml
+++ b/operator/molecule/ossmplugin-cr.yaml
@@ -3,7 +3,7 @@ kind: OSSMPlugin
 metadata:
   name: ossmplugin
 spec:
+  version: "{{ ossmplugin.spec_version }}"
   deployment:
-    imageName: "{{ ossmplugin.imageName }}"
-    imagePullPolicy: "{{ ossmplugin.imagePullPolicy }}"
-    imageVersion: "{{ ossmplugin.imageVersion }}"
+    imageName: "{{ ossmplugin.image_name }}"
+    imageVersion: "{{ ossmplugin.image_version }}"

--- a/operator/roles/default/ossmplugin-deploy/tasks/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/main.yml
@@ -79,6 +79,27 @@
   - current_cr.status.deployment.namespace is defined
   - current_cr.status.deployment.namespace != ossmplugin_vars.deployment.namespace
 
+# If no Kiali URL is provided, try to auto-discover one, first in the CR's namespace then anywhere else. If Kiali is not found, abort.
+- name: Auto-discover the Kiali URL - preference goes to a Kiali installed in the same namespace as the CR
+  vars:
+    kiali_in_namespace: "{{ lookup(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
+    kiali_anywhere: "{{ lookup(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+  set_fact:
+    kiali_route_host: "{{ kiali_in_namespace[0].spec.host if kiali_in_namespace | length > 0 else (kiali_anywhere[0].spec.host if kiali_anywhere | length > 0 else '') }}"
+  when:
+  - ossmplugin_vars.kiali.url == ""
+
+- fail:
+    msg: "Failed to auto-discover the Kiali URL. Make sure Kiali is installed. You can specify 'kiali.url' in the CR if there is a Kiali URL endpoint the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmplugin_vars.kiali.url == ""
+  - kiali_route_host is not defined or kiali_route_host == ""
+
+- set_fact:
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'kiali': {'url': 'https://' + kiali_route_host}}, recursive=True) }}"
+  when:
+  - ossmplugin_vars.kiali.url == ""
+
 - set_fact:
     status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
   loop: "{{ data[0] | zip(data[1]) | list }}"
@@ -98,6 +119,8 @@
       environment: "{{ status_environment | default({}) }}"
       deployment:
         namespace: "{{ ossmplugin_vars.deployment.namespace }}"
+      kiali:
+        url: "{{ ossmplugin_vars.kiali.url }}"
 
 - name: Only allow ad-hoc OSSM Plugin image when appropriate
   fail:


### PR DESCRIPTION
You can now leave the `spec.kiali.url` unspecified (or set it to empty string `""`, which is the default) in the CR, and the operator will attempt to auto-discover it. It will first give precedence to any Kiali route it finds in the same namespace where the CR is, otherwise, it will look for any Kiali installed anywhere in the cluster and use that.

You can always override this auto-discovery mechanism by setting `spec.kiali.url` in the CR.

