### PR TITLE
Support generating OLM bundles with different channels.

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -112,7 +112,7 @@ install-cr: create-test-namespace
 
 ## uninstall-cr: Deletes the test OSSM Plugin CR from the cluster and waits for the operator to finalize the deletion.
 uninstall-cr:
-	${OC} delete --ignore-not-found=true -f "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml"
+	(${OC} get crd ossmplugins.kiali.io &> /dev/null && ${OC} delete --ignore-not-found=true -f "${OPERATOR_DIR}/deploy/ossmplugin-cr-dev.yaml") || true
 
 ## purge-all-crs: Purges all OSSM Plugin CRs from the cluster, forcing them to delete without the operator finalizing them.
 purge-all-crs: .ensure-oc-login

--- a/operator/manifests/generate-annotations.sh
+++ b/operator/manifests/generate-annotations.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -c|--channels) CHANNELS="$2" ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+$0 [option...]
+
+Using the settings passed to this script, this will print to stdout a new annotations.yaml generated from the template.
+
+Valid options:
+  -c|--channels <channel list>
+      A comma-separate list of channels that will be associated with the bundle.
+      The first channel in the list will be considered the default channel.
+      Default: candidate
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key].  Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+ANNOTATIONS_YAML="$(ls -1 ${SCRIPT_DIR}/template/metadata/annotations.yaml)"
+if [ -z ${ANNOTATIONS_YAML} ]; then
+  echo "Something is wrong. Cannot find the template annotations.yaml file at ${SCRIPT_DIR}/template/metadata/annotations.yaml"
+  exit 1
+fi
+
+# Generate the new annotations.yaml content from the template
+export CHANNELS="${CHANNELS:-candidate}"
+export DEFAULT_CHANNEL="$(echo ${CHANNELS} | cut -d ',' -f1)"
+cat ${ANNOTATIONS_YAML} | envsubst

--- a/operator/manifests/generate-dockerfile.sh
+++ b/operator/manifests/generate-dockerfile.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -c|--channels) CHANNELS="$2" ; shift;shift ;;
+    -h|--help)
+      cat <<HELPMSG
+$0 [option...]
+
+Using the settings passed to this script, this will print to stdout a new bundle.Dockerfile generated from the template.
+
+Valid options:
+  -c|--channels <channel list>
+      A comma-separate list of channels that will be associated with the bundle.
+      The first channel in the list will be considered the default channel.
+      Default: candidate
+HELPMSG
+      exit 1
+      ;;
+    *)
+      echo "Unknown argument [$key].  Aborting."
+      exit 1
+      ;;
+  esac
+done
+
+BUNDLE_DOCKERFILE="$(ls -1 ${SCRIPT_DIR}/template/bundle.Dockerfile)"
+if [ -z ${BUNDLE_DOCKERFILE} ]; then
+  echo "Something is wrong. Cannot find the template bundle.Dockerfile at ${SCRIPT_DIR}/template/bundle.Dockerfile"
+  exit 1
+fi
+
+# Generate the new annotations.yaml content from the template
+export CHANNELS="${CHANNELS:-candidate}"
+export DEFAULT_CHANNEL="$(echo ${CHANNELS} | cut -d ',' -f1)"
+cat ${BUNDLE_DOCKERFILE} | envsubst

--- a/operator/manifests/ossmplugin-community/0.0.1/bundle.Dockerfile
+++ b/operator/manifests/ossmplugin-community/0.0.1/bundle.Dockerfile
@@ -4,8 +4,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ossmplugin
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.bundle.channels.v1=candidate
+LABEL operators.operatorframework.io.bundle.channel.default.v1=candidate
 
 COPY manifests /manifests/
 COPY metadata /metadata/

--- a/operator/manifests/ossmplugin-community/0.0.1/metadata/annotations.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: candidate
+  operators.operatorframework.io.bundle.channels.v1: candidate
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/operator/manifests/ossmplugin-ossm/metadata/annotations.yaml
+++ b/operator/manifests/ossmplugin-ossm/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: candidate
+  operators.operatorframework.io.bundle.channels.v1: candidate
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/operator/manifests/template/bundle.Dockerfile
+++ b/operator/manifests/template/bundle.Dockerfile
@@ -4,8 +4,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ossmplugin
-LABEL operators.operatorframework.io.bundle.channels.v1=stable
-LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNELS}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=${DEFAULT_CHANNEL}
 
 COPY manifests /manifests/
 COPY metadata /metadata/

--- a/operator/manifests/template/metadata/annotations.yaml
+++ b/operator/manifests/template/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: ${DEFAULT_CHANNEL}
+  operators.operatorframework.io.bundle.channels.v1: ${CHANNELS}
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
 Don't use stable channel by default; use "candidate".

Channels names are per best practices defined at https://olm.operatorframework.io/docs/best-practices/channel-naming/

We can use when we are shipping tech preview plugins (we don't want them in a channel named "stable", instead they will be in "candidate" channel) but yet later ship supported versions (which then use "stable" channel).