### PR TITLE
Propagate session token

### DIFF
--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-nginx.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/configmap-nginx.yaml
@@ -6,7 +6,7 @@ metadata:
   labels: {{ ossmplugin_resource_metadata_labels }}
 data:
   nginx.conf: |
-    error_log /dev/stdout info;
+    error_log /dev/stdout;
     events {}
     http {
       access_log         /dev/stdout;
@@ -17,6 +17,9 @@ data:
         listen              9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
+
+        add_header oauth_token "$http_Authorization";
+
         location / {
           root                /usr/share/nginx/html;
         }

--- a/plugin/manifest.yaml
+++ b/plugin/manifest.yaml
@@ -74,17 +74,21 @@ metadata:
     app.kubernetes.io/part-of: servicemesh-plugin
 data:
   nginx.conf: |
-    error_log /dev/stdout info;
+    error_log /dev/stdout;
     events {}
     http {
       access_log         /dev/stdout;
       include            /etc/nginx/mime.types;
       default_type       application/octet-stream;
       keepalive_timeout  65;
+
       server {
         listen              9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
+
+        add_header oauth_token "$http_Authorization";
+
         location / {
           root                /usr/share/nginx/html;
         }

--- a/plugin/src/components/GraphPage.tsx
+++ b/plugin/src/components/GraphPage.tsx
@@ -1,22 +1,35 @@
 import * as React from 'react';
-import {properties} from "../properties";
-import {consoleFetchJSON} from "@openshift-console/dynamic-plugin-sdk";
+import {kioskUrl, properties} from "../properties";
+import {consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
 
 const GraphPage = () => {
-    const [kialiBaseUrl, setKialiBaseUrl] = React.useState();
-
+    const [kialiUrl, setKialiUrl] = React.useState({
+        baseUrl: '',
+        token: '',
+    });
     React.useEffect(() => {
-        consoleFetchJSON(properties.pluginConfig)
+        consoleFetch(properties.pluginConfig)
             .then((response) => {
-                setKialiBaseUrl(response.kialiUrl);
+                const headerOauthToken = response.headers.get('oauth_token');
+                const kialiToken = 'oauth_token=';
+                response.json().then((payload) => {
+                    setKialiUrl({
+                        baseUrl: payload.kialiUrl,
+                        token: kialiToken  + (
+                            headerOauthToken && headerOauthToken.startsWith('Bearer ') ?
+                                headerOauthToken.substring('Bearer '.length) : ''
+                        ),
+                    });
+                });
             })
             .catch((e) => console.error(e));
     }, []);
 
+    const iFrameUrl = kialiUrl.baseUrl + '/console/graph/namespaces/?' + kioskUrl + '&' + kialiUrl.token;
     return (
         <>
             <iframe
-                src={kialiBaseUrl + '/console/graph/namespaces/?kiosk=true'}
+                src={iFrameUrl}
                 style={{overflow: 'hidden', height: '100%', width: '100%' }}
                 height="100%"
                 width="100%"

--- a/plugin/src/components/OverviewPage.tsx
+++ b/plugin/src/components/OverviewPage.tsx
@@ -1,22 +1,34 @@
 import * as React from 'react';
-import {properties} from "../properties";
-import { consoleFetchJSON } from "@openshift-console/dynamic-plugin-sdk";
+import {kioskUrl, properties} from "../properties";
+import { consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
 
 const OverviewPage = () => {
-    const [kialiBaseUrl, setKialiBaseUrl] = React.useState();
-
+    const [kialiUrl, setKialiUrl] = React.useState({
+        baseUrl: '',
+        token: '',
+    });
     React.useEffect(() => {
-        consoleFetchJSON(properties.pluginConfig)
+        consoleFetch(properties.pluginConfig)
             .then((response) => {
-                setKialiBaseUrl(response.kialiUrl);
+                const headerOauthToken = response.headers.get('oauth_token');
+                const kialiToken = 'oauth_token=';
+                response.json().then((payload) => {
+                    setKialiUrl({
+                        baseUrl: payload.kialiUrl,
+                        token: kialiToken  + (
+                            headerOauthToken && headerOauthToken.startsWith('Bearer ') ?
+                                headerOauthToken.substring('Bearer '.length) : ''
+                        ),
+                    });
+                });
             })
             .catch((e) => console.error(e));
     }, []);
-
+    const iFrameUrl = kialiUrl.baseUrl + '/console/overview/?' + kioskUrl + '&' + kialiUrl.token;
     return (
         <>
             <iframe
-                src={kialiBaseUrl + '/console/overview/?kiosk=true'}
+                src={iFrameUrl}
                 style={{overflow: 'hidden', height: '100%', width: '100%' }}
                 height="100%"
                 width="100%"

--- a/plugin/src/properties.ts
+++ b/plugin/src/properties.ts
@@ -10,8 +10,7 @@ export type Config = {
     kialiUrl: string;
 }
 
-
-
+export const kioskUrl = 'kiosk=true';
 
 
 


### PR DESCRIPTION
This work propagates the OpenShift Console session token into Kiali using the new change introduced in https://github.com/kiali/kiali/pull/5133

When the OpenShift console talks with the plugins, it already propagates the session token, with a change in the configuration, the Nginx server can add that info in the response header.

At the same time that the plugin asks for the Kiali URL, the token is fetched and propagated to Kiali.

How to test:

(1) Validate that the user hasn't logged into Kiali:
![image](https://user-images.githubusercontent.com/1662329/171828409-3c6eed96-a358-4ccd-b887-9dce841145d7.png)

(2) Access the OpenShift Console, and validate that the user is logged into Kiali WITHOUT requiring the previous login in the standalone app:
![image](https://user-images.githubusercontent.com/1662329/171828714-47c23985-dc23-47bf-adb0-4cb320626de2.png)

(3) Check that being logged into OpenShift Console DOESN'T log the user into Kiali standalone, that authentication only should work in the context of the OpenShift Console (or a special bookmark containing the credentials).
