### PR TITLE
WIP Update image dependencies

### DIFF
--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,3 +1,4 @@
+# These pulls brings hundreds of CVEs
 FROM node:16 AS build
 
 ADD . /usr/src/app


### PR DESCRIPTION
The dependencies used for the "servicemesh-plugin" images bring a lot of CVEs into Quay.
I'm going to adjust these dependencies in the same way that other OpenShift Console plugins are doing.
