### PR TITLE
move to yet another ansible quay repo to run molecule

### DIFF
--- a/operator/molecule/docker/Dockerfile
+++ b/operator/molecule/docker/Dockerfile
@@ -1,12 +1,1 @@
-FROM quay.io/ansible/toolset:3.5.0
-ENV PACKAGES="\
-gettext \
-gcc \
-libc-dev \
-curl \
-bash \
-openssl \
-"
-RUN apt-get update && apt-get install -y ${PACKAGES}
-RUN pip install openshift junit-xml jmespath docker kubernetes
-RUN ansible-galaxy collection install kubernetes.core
+FROM quay.io/ansible/creator-ee:v0.5.2

--- a/operator/molecule/docker/Dockerfile
+++ b/operator/molecule/docker/Dockerfile
@@ -1,1 +1,3 @@
 FROM quay.io/ansible/creator-ee:v0.5.2
+RUN pip install jmespath
+RUN ansible-galaxy collection install community.general kubernetes.core

--- a/operator/molecule/requirements.txt
+++ b/operator/molecule/requirements.txt
@@ -1,6 +1,6 @@
 # Project requirements
 # 'pip install -r requirements.txt'
-# In addition to these, you must also exec "ansible-galaxy collection install kubernetes.core"
+# In addition to these, you must also exec "ansible-galaxy collection install community.general kubernetes.core"
 molecule
 openshift
 jmespath


### PR DESCRIPTION
They removed the quay repo (again) with the base image we need to run molecule. We need to move to a third quay repo.

This fixes the problem found in https://github.com/kiali/openshift-servicemesh-plugin/pull/8

See: https://github.com/ansible-community/molecule/discussions/3206

TO TEST:
1. You must be oc logged into a OpenShift 4.10 cluster
2. You must have Istio and Kiali installed
3. `make -e FORCE_MOLECULE_BUILD=true -e MOLECULE_SCENARIO="config-values-test" operator-create molecule-build molecule-test`

