### PR TITLE
plugin will log version/commit at startup

### DIFF
--- a/make/Makefile.plugin.mk
+++ b/make/Makefile.plugin.mk
@@ -24,7 +24,7 @@ build-plugin:
 
 ## build-plugin-image: Builds the plugin and its container image.
 build-plugin-image: build-plugin
-	${DORP} build -t ${PLUGIN_QUAY_TAG} ${PLUGIN_DIR}
+	${DORP} build --build-arg VERSION="${VERSION}" --build-arg COMMIT_HASH="${COMMIT_HASH}" -t ${PLUGIN_QUAY_TAG} ${PLUGIN_DIR}
 
 ## push-plugin-image: Pushes the plugin container image to quay.io.
 push-plugin-image:

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -8,3 +8,9 @@ FROM nginx:stable
 
 RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+
+# Have the plugin log its version immediately upon startup
+ARG VERSION
+ARG COMMIT_HASH
+RUN echo "echo 'OpenShift Service Mesh Plugin: Version=[${VERSION}], Commit=[${COMMIT_HASH}]'" > /docker-entrypoint.d/01-log-version.sh
+RUN chmod ug+x /docker-entrypoint.d/01-log-version.sh


### PR DESCRIPTION
fixes: https://github.com/kiali/openshift-servicemesh-plugin/issues/16

to test, just run the plugin in the cluster and look at the pod logs - the first several lines will look like this - see the version/commit that prints out:

```
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/01-log-version.sh
OpenShift Service Mesh Plugin: Version=[v0.0.1-SNAPSHOT], Commit=[e699245fa9953e6678e009da17fae2fd61e05c7e]
```

This PR only adds that one script which prints out that one line to the output: `OpenShift Service Mesh Plugin: Version=[v0.0.1-SNAPSHOT], Commit=[e699245fa9953e6678e009da17fae2fd61e05c7e]`