### PR TITLE
put kiali version in CR status so we know what the plugin is talking to

### DIFF
--- a/operator/roles/default/ossmplugin-deploy/tasks/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/main.yml
@@ -107,13 +107,20 @@
   when:
   - ossmplugin_vars.kiali.url == ""
 
+- name: Determine Kiali version
+  set_fact:
+    kiali_version: "{{ lookup('url', ossmplugin_vars.kiali.url + '/api', split_lines='no', validate_certs='no') | from_json | json_query(q) }}"
+  vars:
+    q: status."Kiali version"
+  ignore_errors: yes
+
 - set_fact:
     status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
   loop: "{{ data[0] | zip(data[1]) | list }}"
   vars:
     data:
-    - ['isMaistra', 'kubernetesVersion', 'openshiftVersion', 'operatorVersion']
-    - ["{{is_maistra}}", "{{k8s_version|default('')}}", "{{openshift_version|default('')}}", "{{operator_version}}"]
+    - ['isMaistra', 'kialiVersion', 'kubernetesVersion', 'openshiftVersion', 'operatorVersion']
+    - ["{{is_maistra}}", "{{kiali_version|default('unknown')}}", "{{k8s_version|default('')}}", "{{openshift_version|default('')}}", "{{operator_version}}"]
   when:
   - item.1 != ""
   - item.1 != "false"


### PR DESCRIPTION
Add new `kialiVersion` field in the CR `status`. This is going to be useful when people are installing the plugin and things aren't working - we will need to know what version of Kiali the plugin is talking to.

This is what the status field will now look like (notice the new kialiVersion field):

```sh
$ oc get -n ossmplugin ossmplugins.kiali.io ossmplugin -o jsonpath={.status.environment} | jq
```

```json
{
  "kialiVersion": "v1.52.0-SNAPSHOT",
  "kubernetesVersion": "1.23.3+e419edf",
  "openshiftVersion": "4.10.5",
  "operatorVersion": "v0.0.1"
}

```