### PR TITLE
Introduce listeners for plugin navigation

### DIFF
--- a/plugin/src/components/GraphPage.tsx
+++ b/plugin/src/components/GraphPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {kioskUrl, properties} from "../properties";
+import {initKialiListeners, kioskUrl, properties} from "../properties";
 import {consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
 
 const GraphPage = () => {
@@ -7,6 +7,9 @@ const GraphPage = () => {
         baseUrl: '',
         token: '',
     });
+
+    initKialiListeners();
+
     React.useEffect(() => {
         consoleFetch(properties.pluginConfig)
             .then((response) => {
@@ -25,7 +28,7 @@ const GraphPage = () => {
             .catch((e) => console.error(e));
     }, []);
 
-    const iFrameUrl = kialiUrl.baseUrl + '/console/graph/namespaces/?' + kioskUrl + '&' + kialiUrl.token;
+    const iFrameUrl = kialiUrl.baseUrl + '/console/graph/namespaces/?' + kioskUrl() + '&' + kialiUrl.token;
     return (
         <>
             <iframe

--- a/plugin/src/components/IstioConfigList.tsx
+++ b/plugin/src/components/IstioConfigList.tsx
@@ -7,6 +7,7 @@ import {
     TableColumn,
     TableData, useK8sWatchResource, useListPageFilter, VirtualizedTable
 } from "@openshift-console/dynamic-plugin-sdk";
+import {initKialiListeners} from "../properties";
 
 const resources = [
     {
@@ -96,6 +97,9 @@ const VirtualServiceTable = ({
 };
 
 const IstioConfigList = () => {
+
+    initKialiListeners();
+
     const watches = resources.map(({ group, version, kind }) => {
         const [data, loaded, error] = useK8sWatchResource<VirtualService[]>({
             groupVersionKind: { group, version, kind },

--- a/plugin/src/components/MeshTab.tsx
+++ b/plugin/src/components/MeshTab.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {useHistory} from "react-router";
-import {kioskUrl, properties} from "../properties";
+import {initKialiListeners, kioskUrl, properties} from "../properties";
 import {consoleFetch} from "@openshift-console/dynamic-plugin-sdk";
-
 
 const kialiTypes = {
     services: 'services',
@@ -17,6 +16,9 @@ const MeshTab = () => {
         baseUrl: '',
         token: '',
     });
+
+    initKialiListeners();
+
     React.useEffect(() => {
         consoleFetch(properties.pluginConfig)
             .then((response) => {
@@ -59,10 +61,10 @@ const MeshTab = () => {
         }
     }
 
-    let iFrameUrl = kialiUrl.baseUrl + '/console/namespaces/' + namespace + '/' + type + '/' + id + '?' + kioskUrl + '&' + kialiUrl.token;
+    let iFrameUrl = kialiUrl.baseUrl + '/console/namespaces/' + namespace + '/' + type + '/' + id + '?' + kioskUrl() + '&' + kialiUrl.token;
     // Projects is a special case that will forward the graph in the iframe
     if (items[1] === 'projects') {
-        iFrameUrl = kialiUrl.baseUrl +  '/console/graph/namespaces?namespaces=' + id + '&' + kioskUrl + '&' + kialiUrl.token;
+        iFrameUrl = kialiUrl.baseUrl +  '/console/graph/namespaces?namespaces=' + id + '&' + kioskUrl() + '&' + kialiUrl.token;
     }
     // TODO Obviously, this iframe is a PoC
     return (

--- a/plugin/src/components/OverviewPage.tsx
+++ b/plugin/src/components/OverviewPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {kioskUrl, properties} from "../properties";
+import {initKialiListeners, kioskUrl, properties} from "../properties";
 import { consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
 
 const OverviewPage = () => {
@@ -7,6 +7,9 @@ const OverviewPage = () => {
         baseUrl: '',
         token: '',
     });
+
+    initKialiListeners();
+
     React.useEffect(() => {
         consoleFetch(properties.pluginConfig)
             .then((response) => {
@@ -24,7 +27,8 @@ const OverviewPage = () => {
             })
             .catch((e) => console.error(e));
     }, []);
-    const iFrameUrl = kialiUrl.baseUrl + '/console/overview/?' + kioskUrl + '&' + kialiUrl.token;
+
+    const iFrameUrl = kialiUrl.baseUrl + '/console/overview/?' + kioskUrl() + '&' + kialiUrl.token;
     return (
         <>
             <iframe


### PR DESCRIPTION
Related to https://github.com/kiali/openshift-servicemesh-plugin/issues/21

This work integrates the changes from https://github.com/kiali/kiali/pull/5211 into the plugin.

It captures the messages from Kiali to perform the navigation inside the plugin:
![image](https://user-images.githubusercontent.com/1662329/173835520-7a5723b9-e0bf-4384-8854-90e00da5949d.png)

When a user clicks on the "Overview" actions, the user will navigate to the "Graph" or "Istio Config" page of the plugin:
![image](https://user-images.githubusercontent.com/1662329/173835739-e0a79ef8-1026-4956-9a21-160a98c69c3d.png)

Time and duration parameters are propagated.

There are some changes in the links on embedded mode, that I think may more sense:
![image](https://user-images.githubusercontent.com/1662329/173835997-ab94c5cf-765e-4afe-a28d-ae18d8b7fbab.png)

Status links (healthy/degraded/failures) should be redirected to the graph but with a "find filter" applied:
![image](https://user-images.githubusercontent.com/1662329/173836158-6ce11e05-fb6c-42cb-98ea-c2bde549caeb.png)

That can simplify some features that OpenShift Console doesn't provide (i.e. a list of applications, or a multi-namespace list).

This work is only scoped to the "Service Mesh -> Overview" page, where all the links should be now handled.

Other pages (i.e Graph, Istio Config, or the Service Mesh tabs) are not yet implemented.

