### PR TITLE
Update deprecated tab entry point

### DIFF
--- a/plugin/console-extensions.json
+++ b/plugin/console-extensions.json
@@ -62,91 +62,108 @@
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
-        "version": "v1",
         "group": "project.openshift.io",
-        "kind": "Project"
+        "kind": "Project",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
-        "version": "v1",
         "group": "",
-        "kind": "Pod"
+        "kind": "Pod",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
         "group": "apps",
-        "kind": "Deployment"
+        "kind": "Deployment",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
         "group": "apps.openshift.io",
-        "kind": "DeploymentConfig"
+        "kind": "DeploymentConfig",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
         "group": "apps",
-        "kind": "StatefulSet"
+        "kind": "StatefulSet",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
-        "version": "v1",
         "group": "",
-        "kind": "Service"
+        "kind": "Service",
+        "version": "v1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   },
   {
-    "type": "console.page/resource/tab",
+    "type": "console.tab/horizontalNav",
     "properties": {
       "model": {
-        "version": "v1beta",
         "group": "networking.istio.io",
-        "kind": "VirtualService"
+        "kind": "VirtualService",
+        "version": "v1beta1"
       },
-      "component": { "$codeRef": "MeshTab" },
-      "name": "Service Mesh",
-      "href": "servicemesh"
+      "page": {
+        "name": "Service Mesh",
+        "href": "servicemesh"
+      },
+      "component": { "$codeRef": "MeshTab" }
     }
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/55

Also, I was checking how to add the "Service Mesh" tab to the Istio Config details:

![image](https://user-images.githubusercontent.com/1662329/183882379-f1cb118d-10a3-4d2a-9933-cf7ab844608c.png)

The "VirtualService" is added just as an example, but it's not implemented, probably, it would require a different plugin component for that tab.

But the scope of the Istio Config details is filled in a different issue:

https://github.com/kiali/openshift-servicemesh-plugin/issues/52

It's not part of this work.

To test this work, just smoke navigation on the mesh tabs would be enough.

There is no testing in place in the plugin, but I think it could be a good moment to add a basic skeleton that would manually run some of these testing as described in the issue:

https://github.com/kiali/openshift-servicemesh-plugin/issues/44