### PR TITLE
Introduce Kiali validations to Istio Config plugin page

### DIFF
--- a/operator/crd-docs/cr/kiali.io_v1alpha1_ossmplugin.yaml
+++ b/operator/crd-docs/cr/kiali.io_v1alpha1_ossmplugin.yaml
@@ -17,4 +17,7 @@ spec:
     namespace: ""
 
   kiali:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 0
     url: ""

--- a/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
+++ b/operator/crd-docs/crd/kiali.io_ossmplugins.yaml
@@ -85,6 +85,15 @@ spec:
               kiali:
                 type: object
                 properties:
+                  serviceName:
+                    description: "The internal Kiali service that the OS Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    type: string
+                  serviceNamespace:
+                    description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+                    type: string
+                  servicePort:
+                    description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    type: integer
                   url:
                     description: "The main Kiali endpoint URL that the OSSM Plugin will use to communicate with Kiali. If empty, an attempt will be made to auto-discover it. If Kiali is installed in the same namespace as the CR, it will take precedence over any other Kiali installation. Otherwise, the first Kiali route found in the cluster will be used."
                     type: string

--- a/operator/deploy/ossmplugin-cr-dev.yaml
+++ b/operator/deploy/ossmplugin-cr-dev.yaml
@@ -13,4 +13,8 @@ spec:
     imagePullSecrets:
     - ${PULL_SECRET_NAME}
   kiali:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 0
     url: ""
+

--- a/operator/dev-playbook-config/dev-hosts.yaml
+++ b/operator/dev-playbook-config/dev-hosts.yaml
@@ -9,6 +9,9 @@ all:
       imageVersion: dev
 
     kiali:
+      serviceName: ""
+      serviceNamespace: ""
+      servicePort: 0
       url: ""
 
     # The Operator SDK creates a "ansible_operator_meta" variable

--- a/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
+++ b/operator/dev-playbook-config/dev-ossmplugin-cr.yaml
@@ -23,4 +23,7 @@ spec:
     imageVersion: dev
 
   kiali:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 0
     url: ""

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
@@ -84,6 +84,21 @@ spec:
       - kind: ConfigMap
         version: v1
       specDescriptors:
+      - displayName: Kiali Service Name
+        description: "The internal Kiali service that the OS Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.serviceName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Namespace
+        description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+        path: kiali.serviceNamespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Port
+        description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.servicePort
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
       - displayName: Kiali URL
         description: "The root endpoint URL to the Kiali UI Console. If empty, an attempt to auto-discover it will be made."
         path: kiali.url

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
@@ -29,6 +29,9 @@ metadata:
           },
           "spec": {
             "kiali": {
+              "serviceName": "",
+              "serviceNamespace": "",
+              "servicePort": 0,
               "url": ""
             }
           }
@@ -90,6 +93,21 @@ spec:
       - kind: ConfigMap
         version: v1
       specDescriptors:
+      - displayName: Kiali Service Name
+        description: "The internal Kiali service that the OS Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.serviceName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Namespace
+        description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+        path: kiali.serviceNamespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Port
+        description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.servicePort
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
       - displayName: Kiali URL
         description: "The root endpoint URL to the Kiali UI Console. If empty, an attempt to auto-discover it will be made."
         path: kiali.url

--- a/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
@@ -23,6 +23,9 @@ metadata:
           },
           "spec": {
             "kiali": {
+              "serviceName": "",
+              "serviceNamespace": "",
+              "servicePort": 0,      
               "url": ""
             }
           }
@@ -84,6 +87,21 @@ spec:
       - kind: ConfigMap
         version: v1
       specDescriptors:
+      - displayName: Kiali Service Name
+        description: "The internal Kiali service that the OS Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.serviceName
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Namespace
+        description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+        path: kiali.serviceNamespace
+        x-descriptors:
+          - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - displayName: Kiali Service Port
+        description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+        path: kiali.servicePort
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
       - displayName: Kiali URL
         description: "The root endpoint URL to the Kiali UI Console. If empty, an attempt to auto-discover it will be made."
         path: kiali.url

--- a/operator/molecule/common/tasks.yml
+++ b/operator/molecule/common/tasks.yml
@@ -48,3 +48,10 @@
 - name: Dump OSSMPlugin ConfigMap
   debug:
     msg: "{{ ossmplugin_configmap }}"
+
+- name: Get OSSMPlugin ConsolePlugin
+  set_fact:
+    ossmplugin_consoleplugin: "{{ lookup('kubernetes.core.k8s', api_version='console.openshift.io/v1alpha1', kind='ConsolePlugin', namespace=ossmplugin.install_namespace, resource_name='servicemesh') }}"
+- name: Dump OSSMPlugin ConsolePlugin
+  debug:
+    msg: "{{ ossmplugin_consoleplugin }}"

--- a/operator/molecule/config-values-test/converge.yml
+++ b/operator/molecule/config-values-test/converge.yml
@@ -16,6 +16,18 @@
     debug:
       msg: "{{ current_ossmplugin_cr }}"
 
+  - name: Confirm the Kiali Service Name is as expected
+    assert:
+      that: "{{ ossmplugin_consoleplugin.spec.proxy[0].service.name == current_ossmplugin_cr.status.kiali.serviceName }}"
+
+  - name: Confirm the Kiali Service Namespace is as expected
+    assert:
+      that: "{{ ossmplugin_consoleplugin.spec.proxy[0].service.namespace == current_ossmplugin_cr.status.kiali.serviceNamespace }}"
+
+  - name: Confirm the Kiali Service Port is as expected
+    assert:
+      that: "{{ ossmplugin_consoleplugin.spec.proxy[0].service.port == (current_ossmplugin_cr.status.kiali.servicePort | int) }}"
+
   - name: Confirm the Kiali URL is as expected
     assert:
       that: "{{ ossmplugin_configmap.kialiUrl == current_ossmplugin_cr.status.kiali.url }}"

--- a/operator/roles/default/ossmplugin-deploy/defaults/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/defaults/main.yml
@@ -19,4 +19,7 @@ ossmplugin_defaults:
     namespace: ""
 
   kiali:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 0
     url: ""

--- a/operator/roles/default/ossmplugin-deploy/tasks/main.yml
+++ b/operator/roles/default/ossmplugin-deploy/tasks/main.yml
@@ -85,6 +85,36 @@
   - current_cr.status.deployment.namespace is defined
   - current_cr.status.deployment.namespace != ossmplugin_vars.deployment.namespace
 
+- name: Auto-discover the Kiali Service Name - preference goes to a Kiali installed in the same namespace as the CR
+  vars:
+    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
+    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+  set_fact:
+    kiali_service_name: "{{ kiali_in_namespace[0].spec.to.name if kiali_in_namespace | length > 0 else (kiali_anywhere[0].spec.to.name if kiali_anywhere | length > 0 else '') }}"
+  when:
+  - ossmplugin_vars.kiali.serviceName == ""
+  ignore_errors: yes
+
+- name: Auto-discover the Kiali Service Namespace - preference goes to a Kiali installed in the same namespace as the CR
+  vars:
+    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
+    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+  set_fact:
+    kiali_service_namespace: "{{ kiali_in_namespace[0].metadata.namespace if kiali_in_namespace | length > 0 else (kiali_anywhere[0].metadata.namespace if kiali_anywhere | length > 0 else '') }}"
+  when:
+  - ossmplugin_vars.kiali.serviceNamespace == ""
+  ignore_errors: yes
+
+- name: Auto-discover the Kiali Service Port - preference goes to a Kiali installed in the same namespace as the CR
+  vars:
+    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
+    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+  set_fact:
+    kiali_service_port: "{{ kiali_in_namespace[0].spec.port.targetPort if kiali_in_namespace | length > 0 else (kiali_anywhere[0].spec.port.targetPort if kiali_anywhere | length > 0 else 20001) }}"
+  when:
+  - ossmplugin_vars.kiali.servicePort == 0
+  ignore_errors: yes
+
 # If no Kiali URL is provided, try to auto-discover one, first in the CR's namespace then anywhere else. If Kiali is not found, abort.
 - name: Auto-discover the Kiali URL - preference goes to a Kiali installed in the same namespace as the CR
   vars:
@@ -97,15 +127,33 @@
   ignore_errors: yes
 
 - fail:
+    msg: "Failed to auto-discover the Kiali Service Name. Make sure Kiali is installed. You can specify 'kiali.serviceName' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+    - ossmplugin_vars.kiali.serviceName == ""
+    - kiali_service_name is not defined or kiali_service_name == ""
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Service Namespace. Make sure Kiali is installed. You can specify 'kiali.serviceNamespace' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmplugin_vars.kiali.serviceNamespace == ""
+  - kiali_service_namespace is not defined or kiali_service_namespace == ""
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Service Port. Make sure Kiali is installed. You can specify 'kiali.servicePort' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmplugin_vars.kiali.servicePort == 0
+  - kiali_service_port is not defined or kiali_service_port == ""
+
+- fail:
     msg: "Failed to auto-discover the Kiali URL. Make sure Kiali is installed. You can specify 'kiali.url' in the CR if there is a Kiali URL endpoint the plugin can use but cannot be auto-discovered by this operator."
   when:
   - ossmplugin_vars.kiali.url == ""
   - kiali_route_host is not defined or kiali_route_host == ""
 
 - set_fact:
-    ossmplugin_vars: "{{ ossmplugin_vars | combine({'kiali': {'url': 'https://' + kiali_route_host}}, recursive=True) }}"
+    ossmplugin_vars: "{{ ossmplugin_vars | combine({'kiali': {'serviceName': kiali_service_name, 'serviceNamespace': kiali_service_namespace, 'servicePort': kiali_service_port, 'url': 'https://' + kiali_route_host}}, recursive=True) }}"
   when:
-  - ossmplugin_vars.kiali.url == ""
+  - ossmplugin_vars.kiali.serviceName == "" or ossmplugin_vars.kiali.serviceNamespace == "" or ossmplugin_vars.kiali.servicePort == 0 or ossmplugin_vars.kiali.url == ""
 
 - name: Determine Kiali version
   set_fact:
@@ -134,6 +182,9 @@
       deployment:
         namespace: "{{ ossmplugin_vars.deployment.namespace }}"
       kiali:
+        serviceName: "{{ ossmplugin_vars.kiali.serviceName }}"
+        serviceNamespace: "{{ ossmplugin_vars.kiali.serviceNamespace }}"
+        servicePort: "{{ ossmplugin_vars.kiali.servicePort }}"
         url: "{{ ossmplugin_vars.kiali.url }}"
 
 - name: Only allow ad-hoc OSSM Plugin image when appropriate

--- a/operator/roles/default/ossmplugin-deploy/templates/openshift/consoleplugin.yaml
+++ b/operator/roles/default/ossmplugin-deploy/templates/openshift/consoleplugin.yaml
@@ -9,3 +9,11 @@ spec:
     namespace: ossmplugin
     port: 9443
     basePath: "/"
+  proxy:
+  - type: Service
+    alias: kiali
+    authorize: true
+    service:
+      name: {{ ossmplugin_vars.kiali.serviceName }}
+      namespace: {{ ossmplugin_vars.kiali.serviceNamespace }}
+      port: {{ ossmplugin_vars.kiali.servicePort }}

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -17,6 +17,9 @@
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
     "lint": "eslint ./src --fix"
   },
+  "dependencies": {
+    "axios": "0.27.2"
+  },
   "devDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "0.0.13",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "yarn clean && NODE_ENV=production yarn ts-node node_modules/.bin/webpack",
-    "build-dev": "yarn clean && yarn ts-node node_modules/.bin/webpack",
-    "start": "yarn ts-node node_modules/.bin/webpack serve",
+    "build-dev": "yarn clean && NODE_ENV=development yarn ts-node node_modules/.bin/webpack",
+    "start": "NODE_ENV=development KIALI_API_HOST=http://localhost:3000 yarn ts-node node_modules/.bin/webpack serve",
     "start-console": "./start-console.sh",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",

--- a/plugin/src/components/GraphPage.tsx
+++ b/plugin/src/components/GraphPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {initKialiListeners, kioskUrl, properties} from "../utils";
-import {consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
+import { getKialiUrl, initKialiListeners, kioskUrl } from '../kialiIntegration';
 
 const GraphPage = () => {
     const [kialiUrl, setKialiUrl] = React.useState({
@@ -11,21 +10,9 @@ const GraphPage = () => {
     initKialiListeners();
 
     React.useEffect(() => {
-        consoleFetch(properties.pluginConfig)
-            .then((response) => {
-                const headerOauthToken = response.headers.get('oauth_token');
-                const kialiToken = 'oauth_token=';
-                response.json().then((payload) => {
-                    setKialiUrl({
-                        baseUrl: payload.kialiUrl,
-                        token: kialiToken  + (
-                            headerOauthToken && headerOauthToken.startsWith('Bearer ') ?
-                                headerOauthToken.substring('Bearer '.length) : ''
-                        ),
-                    });
-                });
-            })
-            .catch((e) => console.error(e));
+        getKialiUrl()
+            .then(ku => setKialiUrl(ku))
+            .catch(e => console.error(e));
     }, []);
 
     const iFrameUrl = kialiUrl.baseUrl + '/console/graph/namespaces/?' + kioskUrl() + '&' + kialiUrl.token;

--- a/plugin/src/components/IstioConfigList.tsx
+++ b/plugin/src/components/IstioConfigList.tsx
@@ -5,11 +5,13 @@ import {
     RowProps,
     TableColumn,
     TableData, useActiveColumns, useK8sWatchResource, useListPageFilter, VirtualizedTable
-} from "@openshift-console/dynamic-plugin-sdk";
-import {initKialiListeners} from "../utils";
-import {useParams} from "react-router";
+} from '@openshift-console/dynamic-plugin-sdk';
+import { getKialiUrl, initKialiListeners } from '../kialiIntegration';
+import { useParams } from 'react-router';
 import { sortable } from '@patternfly/react-table';
-import {istioResources} from "../k8s/resources";
+import { istioResources, referenceForRsc } from '../k8s/resources';
+import * as API from '../k8s/api';
+import {getValidation, IstioConfigsMap} from '../types/IstioConfigList';
 
 const useIstioTableColumns = (namespace: string) => {
     const columns: TableColumn<K8sResourceCommon>[] = [
@@ -30,6 +32,12 @@ const useIstioTableColumns = (namespace: string) => {
             id: 'kind',
             sort: 'kind',
             title: 'Kind',
+            transforms: [sortable],
+        },
+        {
+            id: 'configuration',
+            sort: 'validations',
+            title: 'Configuration',
             transforms: [sortable],
         },
     ];
@@ -63,6 +71,12 @@ const columns: TableColumn<K8sResourceCommon>[] = [
         title: 'Kind',
         transforms: [sortable],
     },
+    {
+        id: 'configuration',
+        sort: 'validations',
+        title: 'Configuration',
+        transforms: [sortable],
+    },
 ];
 
 const Row = ({ obj, activeColumnIDs }: RowProps<K8sResourceCommon>) => {
@@ -81,6 +95,9 @@ const Row = ({ obj, activeColumnIDs }: RowProps<K8sResourceCommon>) => {
             </TableData>
             <TableData id={columns[2].id} activeColumnIDs={activeColumnIDs}>
                 {obj.kind}
+            </TableData>
+            <TableData id={columns[3].id} activeColumnIDs={activeColumnIDs}>
+                {obj['validations'] ? obj['validations'] : 'N/A'}
             </TableData>
         </>
     );
@@ -136,6 +153,9 @@ const IstioConfigList = () => {
 
     initKialiListeners();
 
+    const [kialiValidations, setKialiValidations] = React.useState<IstioConfigsMap>(undefined);
+    const prevResourceVersion = React.useRef<string[]>([]);
+
     const watches = istioResources.map(({ group, version, kind }) => {
         const [data, loaded, error] = useK8sWatchResource<K8sResourceCommon[]>({
             groupVersionKind: { group, version, kind },
@@ -150,11 +170,53 @@ const IstioConfigList = () => {
     });
 
     const flatData = watches.map(([list]) => list).flat();
+    const resourceVersion = flatData.map(r => referenceForRsc(r));
     const loaded = watches.every(([, loaded, error]) => !!(loaded || error));
+
+    React.useEffect(() => {
+        // Kiali validations should be fetched when:
+        // - All watchers are loaded
+        // - No new updates on the list of the objects
+        const newUpdates =
+            // Initial fetch
+            (resourceVersion.length === 0 && prevResourceVersion.current.length === 0) ||
+            // Different sizes
+            resourceVersion.length != prevResourceVersion.current.length ||
+            // Same size but different elements
+            resourceVersion.some(v => !prevResourceVersion.current.includes(v));
+
+        if (loaded && newUpdates) {
+            getKialiUrl()
+                .then(kialiUrl => {
+                    API.getAllIstioConfigs(kialiUrl.baseUrl, kialiUrl.token)
+                        .then(response => response.data)
+                        .then((kialiValidations) => {
+                            // Update the list of resources present when last fech of Kiali Validations
+                            // Hooks need to maintain this "when to update" logic inside to avoid unnecessary fetches and renders
+                            prevResourceVersion.current = Array.from(resourceVersion);
+                            setKialiValidations(kialiValidations);
+                        });
+                })
+                .catch(error => console.error('Could not connect to Kiali API', error));
+        }
+        // Deps trigger the hook, but those are not "enough", inner logic is needed to check changes
+    }, [loaded, resourceVersion, prevResourceVersion]);
+
+    // On new resources and/or validations, a combination task is required
+    // This uses a "trick" to add a dynamic "validations" field to the K8sResourceCommon type
+    // Probably it can be added a custom type, but that will trigger more refactoring on the standard classes used for tables and filters
+    const combinedData = React.useMemo(() => {
+        if (loaded && kialiValidations) {
+            flatData.forEach(d => d['validations'] = getValidation(kialiValidations, d.kind, d.metadata.name, d.metadata.namespace))
+        }
+        return flatData;
+    }, [flatData, kialiValidations, loaded])
+
     const [data, filteredData, onFilterChange] = useListPageFilter(
-        flatData,
+        combinedData,
         filters,
     );
+
     const columns = useIstioTableColumns(ns);
     return (
         <>

--- a/plugin/src/components/OverviewPage.tsx
+++ b/plugin/src/components/OverviewPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {initKialiListeners, kioskUrl, properties} from "../utils";
-import { consoleFetch } from "@openshift-console/dynamic-plugin-sdk";
+import {getKialiUrl, initKialiListeners, kioskUrl} from '../kialiIntegration';
 
 const OverviewPage = () => {
     const [kialiUrl, setKialiUrl] = React.useState({
@@ -11,21 +10,9 @@ const OverviewPage = () => {
     initKialiListeners();
 
     React.useEffect(() => {
-        consoleFetch(properties.pluginConfig)
-            .then((response) => {
-                const headerOauthToken = response.headers.get('oauth_token');
-                const kialiToken = 'oauth_token=';
-                response.json().then((payload) => {
-                    setKialiUrl({
-                        baseUrl: payload.kialiUrl,
-                        token: kialiToken  + (
-                            headerOauthToken && headerOauthToken.startsWith('Bearer ') ?
-                                headerOauthToken.substring('Bearer '.length) : ''
-                        ),
-                    });
-                });
-            })
-            .catch((e) => console.error(e));
+        getKialiUrl()
+            .then(ku => setKialiUrl(ku))
+            .catch(e => console.error(e));
     }, []);
 
     const iFrameUrl = kialiUrl.baseUrl + '/console/overview/?' + kioskUrl() + '&' + kialiUrl.token;

--- a/plugin/src/k8s/api.ts
+++ b/plugin/src/k8s/api.ts
@@ -21,10 +21,10 @@ export enum HTTP_VERBS {
     PUT = 'put'
 }
 
-const newRequest = <P>(method: HTTP_VERBS, url: string, token: string, queryParams: any, data: any) =>
+const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: any) =>
   axios.request<P>({
     method: method,
-    url: url + '?' + token,
+    url: url,
     data: data,
     headers: getHeadersWithMethod(method),
     params: queryParams
@@ -32,10 +32,9 @@ const newRequest = <P>(method: HTTP_VERBS, url: string, token: string, queryPara
 
 export const getAllIstioConfigs = (
     kialiUrl: string,
-    accessToken: string,
 ): Promise<Response<IstioConfigsMap>> => {
   const params: any = {};
 
   params.validate = true;
-  return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, kialiUrl + ALL_ISTIO_CONFIGS, accessToken, params, {});
+  return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, kialiUrl + ALL_ISTIO_CONFIGS, params, {});
 };

--- a/plugin/src/k8s/api.ts
+++ b/plugin/src/k8s/api.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+import { IstioConfigsMap } from '../types/IstioConfigList';
+
+export interface Response<T> {
+  data: T;
+}
+
+/** Create content type correctly for a given request type */
+const getHeadersWithMethod = method => {
+  return {'Content-Type': 'application/x-www-form-urlencoded'};
+};
+
+const ALL_ISTIO_CONFIGS = '/api/istio/config'
+
+export enum HTTP_VERBS {
+    DELETE = 'DELETE',
+    GET = 'get',
+    PATCH = 'patch',
+    POST = 'post',
+    PUT = 'put'
+}
+
+const newRequest = <P>(method: HTTP_VERBS, url: string, token: string, queryParams: any, data: any) =>
+  axios.request<P>({
+    method: method,
+    url: url + '?' + token,
+    data: data,
+    headers: getHeadersWithMethod(method),
+    params: queryParams
+  });
+
+export const getAllIstioConfigs = (
+    kialiUrl: string,
+    accessToken: string,
+): Promise<Response<IstioConfigsMap>> => {
+  const params: any = {};
+
+  params.validate = true;
+  return newRequest<IstioConfigsMap>(HTTP_VERBS.GET, kialiUrl + ALL_ISTIO_CONFIGS, accessToken, params, {});
+};

--- a/plugin/src/k8s/resources.ts
+++ b/plugin/src/k8s/resources.ts
@@ -1,5 +1,6 @@
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
+// List of Istio resources that the OpenShift Console watches for building the Istio Config page in a "native" way
 export const istioResources = [
   {
     group: 'extensions.istio.io',
@@ -90,7 +91,6 @@ export const kialiIstioResources = {
   '/istio/telemetries':             '/telemetry.istio.io~v1alpha1~Telemetry',
 };
 
-// TODO: Use utility when available in the SDK.
 export const referenceFor = (group: string, version: string, kind: string) =>
   `${group}~${version}~${kind}`;
 
@@ -104,7 +104,11 @@ export const referenceForObj = (obj: K8sResourceCommon) => {
   return referenceFor(group, version, kind);
 };
 
-// This helper would translate Istio Kiali formast
+export const referenceForRsc = (obj: K8sResourceCommon) => {
+  return referenceForObj(obj) + '-' + obj.metadata.namespace + '-' + obj.metadata.name + '-' + obj.metadata.resourceVersion;
+};
+
+// This helper would translate Istio Kiali format
 // i.e. /istio/destinationrules/reviews
 // Into the regular format used for resources in OpenShift
 // i.e. /networking.istio.io~v1beta1~DestinationRule/reviews

--- a/plugin/src/kialiIntegration.ts
+++ b/plugin/src/kialiIntegration.ts
@@ -19,6 +19,23 @@ export type KialiUrl = {
     token: string;
 }
 
+// The ConsolePlugin resource defines a proxy to the internal Kiali Service.
+// This is the main mechanism provided by the OpenShift Console backend to proxy internal requests.
+// This "proxy" is defined under the same domain of the browser and it's mapped to:
+// https://github.com/openshift/enhancements/blob/master/enhancements/console/dynamic-plugins.md#delivering-plugins
+export const CONSOLE_PROXY = '/api/proxy/plugin/servicemesh/kiali';
+
+// Direct requests from the Plugin to Kiali API should use the KialiProxy host.
+// This can be relative to the same domain in production environments but for development it requires a different config.
+export const getKialiProxy = (): string => {
+    if (process.env.NODE_ENV === 'development') {
+        return process.env.KIALI_API_HOST;
+    }
+    return CONSOLE_PROXY;
+}
+
+// The iframes used by the plugin require a public Kiali Url.
+// This url is in a different domain from the OpenShift Console and it would require a token propagation.
 export const getKialiUrl = async function(): Promise<KialiUrl> {
     const kialiToken = 'oauth_token=';
     const kialiUrl = {

--- a/plugin/src/types/IstioConfigList.ts
+++ b/plugin/src/types/IstioConfigList.ts
@@ -1,0 +1,34 @@
+import {
+  Validations,
+} from './IstioObjects';
+
+export declare type IstioConfigsMap = Map<string, IstioConfigList>;
+
+export interface IstioConfigList {
+  validations: Validations;
+}
+
+export function validationKey(name: string, namespace?: string): string {
+  if (namespace !== undefined) {
+    return name + '.' + namespace;
+  } else {
+    return name;
+  }
+}
+
+export function getValidation(istioConfigs: IstioConfigsMap, kind: string, name: string, namespace: string): string {
+  if (istioConfigs[namespace] && istioConfigs[namespace].validations[kind.toLowerCase()] && istioConfigs[namespace].validations[kind.toLowerCase()][validationKey(name, namespace)]) {
+    let validation = istioConfigs[namespace].validations[kind.toLowerCase()][validationKey(name, namespace)]
+    if (validation.checks.filter(i => i.severity === 'error').length > 0) {
+     return "Error"
+    } else {
+     if (validation.checks.filter(i => i.severity === 'warning').length > 0) {
+       return "Warning"
+     } else {
+       return "Valid"
+     }
+    }
+  } else {
+    return "N/A"
+  }
+}

--- a/plugin/src/types/IstioObjects.ts
+++ b/plugin/src/types/IstioObjects.ts
@@ -1,0 +1,37 @@
+// validations are grouped per 'objectType' first in the first map and 'name' in the inner map
+export type Validations = { [key1: string]: { [key2: string]: ObjectValidation } };
+
+export enum ValidationTypes {
+  Error = 'error',
+  Warning = 'warning',
+  Correct = 'correct',
+  Info = 'info'
+}
+
+export const IstioLevelToSeverity = {
+  UNKNOWN: ValidationTypes.Info,
+  ERROR: ValidationTypes.Error,
+  WARNING: ValidationTypes.Warning,
+  INFO: ValidationTypes.Info
+};
+
+export interface ObjectValidation {
+  name: string;
+  objectType: string;
+  valid: boolean;
+  checks: ObjectCheck[];
+  references?: ObjectReference[];
+}
+
+export interface ObjectCheck {
+  code?: string;
+  message: string;
+  severity: ValidationTypes;
+  path: string;
+}
+
+export interface ObjectReference {
+  objectType: string;
+  name: string;
+  namespace: string;
+}

--- a/plugin/webpack.config.ts
+++ b/plugin/webpack.config.ts
@@ -1,6 +1,6 @@
 /* eslint-env node */
 
-import { Configuration as WebpackConfiguration } from "webpack";
+import { Configuration as WebpackConfiguration, DefinePlugin as DefinePlugin } from "webpack";
 import { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
 import * as path from "path";
 import { ConsoleRemotePlugin } from "@openshift-console/dynamic-plugin-sdk-webpack";
@@ -69,7 +69,13 @@ const config: Configuration = {
       writeToDisk: true,
     },
   },
-  plugins: [new ConsoleRemotePlugin()],
+  plugins: [
+      new ConsoleRemotePlugin(),
+      new DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.KIALI_API_HOST': JSON.stringify(process.env.KIALI_API_HOST),
+      }),
+  ],
   devtool: "source-map",
   optimization: {
     chunkIds: "named",

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -929,12 +929,25 @@ array.prototype.flatmap@^1.2.5:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 attr-accept@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
   integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
   dependencies:
     core-js "^2.5.0"
+
+axios@0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -1137,6 +1150,13 @@ colorette@^2.0.10, colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -1310,6 +1330,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0:
   version "2.0.0"
@@ -1846,6 +1871,20 @@ follow-redirects@^1.0.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2611,7 +2650,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
This PR is longer than expected, but it incorporates some important changes:
- The main feature is to improve the Service Mesh -> Istio Config page by adding Kiali validations (@hhovsepy's work).
- In the Istio Config page, the Kubernetes resources are fetched by the OpenShift Console, and the Kiali validations are queried using the Kiali API through the ConsolePlugin proxy.
- The ConsolePlugin needs to provide the information of the internal Kiali Service, and the operator is updated to support this information; the operator uses the same auto-discovery technique used by the Kiali public Url.
- This design is different from the used in the iframes; in this case, the network calls to the Kiali API happen from the same domain of the OpenShift Console, so it has a different approach (it's the expected way for plugins to invoke third party APIs).

@hhovsepy @jmazzitelli, this PR is now ready for review; I've tested it both in developer mode and in an OpenShift cluster.
I've manually tested the molecule tests from the operator.
