### PR TITLE
fix pull secret

### DIFF
--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -29,8 +29,8 @@
 	@for i in {1..5}; do ${OC} get sa default -n ${ALL_IMAGES_NAMESPACE} &> /dev/null && break || echo -n "." && sleep 1; done; echo
 
 .prepare-operator-pull-secret: .prepare-cluster
-	@# base64 encode a pull secret (using the 'default' sa secret) that can be used to pull the bundle index image from the internal image registry
-	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} -z default --to=- | base64 -w0))
+	@# base64 encode a pull secret (using the logged in user token) that can be used to pull the bundle index image from the internal image registry
+	@$(eval OPERATOR_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} --to=- | base64 -w0))
 	@$(eval OPERATOR_IMAGE_PULL_SECRET_NAME ?= ossmplugin-operator-pull-secret)
 
 .create-operator-pull-secret: .prepare-operator-pull-secret

--- a/make/Makefile.cluster.mk
+++ b/make/Makefile.cluster.mk
@@ -46,8 +46,8 @@
 	${OC} delete --ignore-not-found=true secret ${OPERATOR_IMAGE_PULL_SECRET_NAME} --namespace=${OPERATOR_NAMESPACE}
 
 .prepare-plugin-pull-secret: .prepare-cluster
-	@# base64 encode a pull secret (using the 'default' sa secret) that can be used to pull the plugin image from the internal image registry
-	@$(eval PLUGIN_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} -z default --to=- | base64 -w0))
+	@# base64 encode a pull secret (using the logged in user token) that can be used to pull the plugin image from the internal image registry
+	@$(eval PLUGIN_IMAGE_PULL_SECRET_JSON = $(shell ${OC} registry login --registry="$(shell ${OC} registry info --internal)" --namespace=${ALL_IMAGES_NAMESPACE} --to=- | base64 -w0))
 	@$(eval PLUGIN_IMAGE_PULL_SECRET_NAME ?= ossmplugin-plugin-pull-secret)
 
 .create-plugin-pull-secret: .prepare-plugin-pull-secret

--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -86,11 +86,11 @@ get-operator-sdk: .ensure-operator-sdk-exists
 .wait-for-crd:
 	@echo -n "Waiting for the CRD to be established"
 	@i=0 ;\
-	until [ $${i} -eq 30 ] || ${OC} get crd ossmplugins.kiali.io &> /dev/null; do \
+	until [ $${i} -eq 360 ] || ${OC} get crd ossmplugins.kiali.io &> /dev/null; do \
 	    echo -n '.' ; sleep 1 ; (( i++ )) ;\
 	done ;\
 	echo ;\
-	[ $${i} -lt 30 ] || (echo "The CRD does not exist. You should install the operator." && exit 1)
+	[ $${i} -lt 360 ] || (echo "The CRD does not exist. You should install the operator." && exit 1)
 	${OC} wait --for condition=established --timeout=60s crd ossmplugins.kiali.io
 
 ## get-ansible-operator: Downloads the Ansible Operator binary if it is not already in PATH.


### PR DESCRIPTION
OpenShift 4.11 no longer provides a secret with SAs. We need to fix our dev tools to work with 4.11 (but don't break when on 4.10 and before).
This mimics what we did in https://github.com/kiali/kiali/pull/5402

To test: pull the PR and follow the quick start install docs: https://github.com/kiali/openshift-servicemesh-plugin#quick-summary