### PR TITLE
be able to define the image pull policy in the CSV

### DIFF
--- a/make/Makefile.olm.mk
+++ b/make/Makefile.olm.mk
@@ -44,7 +44,7 @@ build-olm-bundle: .prepare-cluster .determine-olm-bundle-version
 	@echo Will bundle version [${BUNDLE_VERSION}]
 	@mkdir -p ${OPERATOR_OUTDIR}/bundle
 	cp -R ${OPERATOR_DIR}/manifests/template/* ${OPERATOR_OUTDIR}/bundle
-	${OPERATOR_DIR}/manifests/generate-csv.sh -ov "NONE" -nv "${BUNDLE_VERSION}" -opin "${CLUSTER_OPERATOR_INTERNAL_NAME}" -opiv "${OPERATOR_CONTAINER_VERSION}" > ${OPERATOR_OUTDIR}/bundle/manifests/ossmplugin.clusterserviceversion.yaml
+	${OPERATOR_DIR}/manifests/generate-csv.sh -ov "NONE" -nv "${BUNDLE_VERSION}" -opin "${CLUSTER_OPERATOR_INTERNAL_NAME}" -opiv "${OPERATOR_CONTAINER_VERSION}" -ipp "Always" > ${OPERATOR_OUTDIR}/bundle/manifests/ossmplugin.clusterserviceversion.yaml
 	${OPERATOR_DIR}/manifests/generate-annotations.sh -c candidate > ${OPERATOR_OUTDIR}/bundle/metadata/annotations.yaml
 	${OPERATOR_DIR}/manifests/generate-dockerfile.sh -c candidate > ${OPERATOR_OUTDIR}/bundle/bundle.Dockerfile
 	${DORP} build -f ${OPERATOR_OUTDIR}/bundle/bundle.Dockerfile -t ${CLUSTER_REPO}/${OLM_BUNDLE_NAME}:${BUNDLE_VERSION}

--- a/operator/manifests/generate-csv.sh
+++ b/operator/manifests/generate-csv.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
+    -ipp|--image-pull-policy)       IMAGE_PULL_POLICY="$2"      ; shift;shift ;;
     -nv|--new-version)              NEW_VERSION="$2"            ; shift;shift ;;
     -opin|--operator-image-name)    OPERATOR_IMAGE_NAME="$2"    ; shift;shift ;;
     -opiv|--operator-image-version) OPERATOR_IMAGE_VERSION="$2" ; shift;shift ;;
@@ -18,6 +19,9 @@ $0 [option...]
 Using the settings passed to this script, this will print to stdout a new CSV generated from the template CSV.
 
 Valid options:
+  -ipp|--image-pull-policy <policy>
+      The operator container image pull policy. Set to "Always" if you are debugging.
+      Default: IfNotPresent
   -nv|--new-version <version string>
       The new version of the CSV.
   -opin|--operator-image-name <repo/org/name>
@@ -78,6 +82,7 @@ fi
 export CSV_NEW_VERSION="${NEW_VERSION}"
 export CSV_PREVIOUS_VERSION="${OLD_VERSION}"
 export CSV_REPLACES_COMMENT
+export IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
 export OPERATOR_IMAGE_NAME
 export OPERATOR_IMAGE_VERSION
 export CREATED_AT="$(date --utc +'%FT%TZ')"

--- a/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-community/0.0.1/manifests/ossmplugin.clusterserviceversion.yaml
@@ -119,7 +119,7 @@ spec:
               containers:
               - name: operator
                 image: quay.io/kiali/ossmplugin-operator:v0.0.1
-                imagePullPolicy: "Always"
+                imagePullPolicy: IfNotPresent
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=ossmplugin-operator"

--- a/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/ossmplugin-ossm/manifests/ossmplugin.clusterserviceversion.yaml
@@ -125,7 +125,7 @@ spec:
               containers:
               - name: operator
                 image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-ossmplugin-rhel8-operator${OSSMPLUGIN_OPERATOR_TAG}
-                imagePullPolicy: "Always"
+                imagePullPolicy: IfNotPresent
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=ossmplugin-operator"

--- a/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmplugin.clusterserviceversion.yaml
@@ -119,7 +119,7 @@ spec:
               containers:
               - name: operator
                 image: ${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}
-                imagePullPolicy: "Always"
+                imagePullPolicy: ${IMAGE_PULL_POLICY}
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=ossmplugin-operator"


### PR DESCRIPTION
without this, you won't be able to do build-debug cycles because the newer operators you push will never get pulled in.