### PR TITLE
do not specify old version of NONE

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,8 +236,7 @@ jobs:
       run: |
         make get-operator-sdk
 
-        # TODO: after the first release, completely remove "--old-version NONE" from the command line below
-        ./operator/manifests/create-new-version.sh --old-version NONE --new-version ${RELEASE_VERSION:1} --channels candidate
+        ./operator/manifests/create-new-version.sh --new-version ${RELEASE_VERSION:1} --channels candidate
 
         git add operator/manifests/
 

--- a/operator/manifests/template/manifests/ossmconsole.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmconsole.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ossmconsole-operator.v${CSV_NEW_VERSION}
   namespace: placeholder
   annotations:
-    #olm.skipRange: '>=0.1.0 <${CSV_NEW_VERSION}'
+    olm.skipRange: '>=0.1.0 <${CSV_NEW_VERSION}'
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: ${OPERATOR_IMAGE_NAME}:${OPERATOR_IMAGE_VERSION}


### PR DESCRIPTION
Only merge this AFTER we release the first (initial) release of the plugin.

For the first release, we need to specify NONE for the old version, but thereafter, there will always be an old version. This PR removes that option to say there is no old version - that allows the script to auto-discover what the last old version is (which is what we want for all subsequent releases).