### PR TITLE
[v0.1] olm metadata to limit the openshift versions and to advertise the multi-arch support

### DIFF
--- a/operator/manifests/ossmconsole-community/0.1.0/bundle.Dockerfile
+++ b/operator/manifests/ossmconsole-community/0.1.0/bundle.Dockerfile
@@ -7,5 +7,7 @@ LABEL operators.operatorframework.io.bundle.package.v1=ossmconsole
 LABEL operators.operatorframework.io.bundle.channels.v1=candidate
 LABEL operators.operatorframework.io.bundle.channel.default.v1=candidate
 
+LABEL com.redhat.openshift.versions=v4.10
+
 COPY manifests /manifests/
 COPY metadata /metadata/

--- a/operator/manifests/ossmconsole-community/0.1.0/manifests/ossmconsole.clusterserviceversion.yaml
+++ b/operator/manifests/ossmconsole-community/0.1.0/manifests/ossmconsole.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: ossmconsole-operator.v0.1.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
   annotations:
     #olm.skipRange: '>=0.1.0 <0.1.0'
     categories: Monitoring,Logging & Tracing

--- a/operator/manifests/ossmconsole-community/0.1.0/metadata/annotations.yaml
+++ b/operator/manifests/ossmconsole-community/0.1.0/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ossmconsole
+  com.redhat.openshift.versions: v4.10

--- a/operator/manifests/ossmconsole-ossm/metadata/annotations.yaml
+++ b/operator/manifests/ossmconsole-ossm/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ossmconsole-ossm
+  com.redhat.openshift.versions: v4.10

--- a/operator/manifests/template/bundle.Dockerfile
+++ b/operator/manifests/template/bundle.Dockerfile
@@ -7,5 +7,7 @@ LABEL operators.operatorframework.io.bundle.package.v1=ossmconsole
 LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNELS}
 LABEL operators.operatorframework.io.bundle.channel.default.v1=${DEFAULT_CHANNEL}
 
+LABEL com.redhat.openshift.versions=v4.10
+
 COPY manifests /manifests/
 COPY metadata /metadata/

--- a/operator/manifests/template/manifests/ossmconsole.clusterserviceversion.yaml
+++ b/operator/manifests/template/manifests/ossmconsole.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: ossmconsole-operator.v${CSV_NEW_VERSION}
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
   annotations:
     #olm.skipRange: '>=0.1.0 <${CSV_NEW_VERSION}'
     categories: Monitoring,Logging & Tracing

--- a/operator/manifests/template/metadata/annotations.yaml
+++ b/operator/manifests/template/metadata/annotations.yaml
@@ -5,3 +5,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ossmconsole
+  com.redhat.openshift.versions: v4.10


### PR DESCRIPTION
I'm cherry picking this over from main just because I want the 0.1 branch to match the metadata that is being published via https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/1613

This PR has no change whatsoever to any code. Its just a change to the olm metadata.