### PR TITLE
Update console service ref to same namespace as console

### DIFF
--- a/operator/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/operator/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -7,7 +7,7 @@ spec:
   displayName: "OpenShift Service Mesh Console"
   service:
     name: ossmconsole
-    namespace: ossmconsole
+    namespace: {{ ossmconsole_vars.deployment.namespace }}
     port: 9443
     basePath: "/"
   proxy:


### PR DESCRIPTION
The ossmconsole Service is deployed in the same namespace as the ossmconsole resource and should use that value instead of hardcoding `ossmconsole`.