### PR TITLE
Added Gateway API Objects listing and filterign support into Config List

### DIFF
--- a/plugin/src/components/IstioConfigList.tsx
+++ b/plugin/src/components/IstioConfigList.tsx
@@ -94,7 +94,7 @@ const Row = ({ obj, activeColumnIDs }: RowProps<K8sResourceCommon>) => {
                 {obj.metadata.namespace}
             </TableData>
             <TableData id={columns[2].id} activeColumnIDs={activeColumnIDs}>
-                {obj.kind}
+                {obj.kind + (obj.apiVersion.includes("k8s") ? " (K8s)" : "")}
             </TableData>
             <TableData id={columns[3].id} activeColumnIDs={activeColumnIDs}>
                 {obj['validations'] ? obj['validations'] : 'N/A'}
@@ -107,15 +107,15 @@ export const filters: RowFilter[] = [
     {
         filterGroupName: 'Kind',
         type: 'kind',
-        reducer: (obj: K8sResourceCommon) => obj.kind,
+        reducer: (obj: K8sResourceCommon) => obj.apiVersion + '.' + obj.kind,
         filter: (input, obj: K8sResourceCommon) => {
             if (!input.selected?.length) {
                 return true;
             }
 
-            return input.selected.includes(obj.kind);
+            return input.selected.includes(obj.apiVersion + '.' + obj.kind);
         },
-        items: istioResources.map(({ kind }) => ({ id: kind, title: kind })),
+        items: istioResources.map(({ group, version, kind, title }) => ({ id: (group + '/' + version + '.' + kind), title: (title? title : kind) })),
     },
 ];
 

--- a/plugin/src/k8s/resources.ts
+++ b/plugin/src/k8s/resources.ts
@@ -8,6 +8,18 @@ export const istioResources = [
     kind: 'WasmPlugin',
   },
   {
+    group: 'gateway.networking.k8s.io',
+    version: 'v1alpha2',
+    kind: 'Gateway',
+    title: 'Gateway (K8s)'
+  },
+  {
+    group: 'gateway.networking.k8s.io',
+    version: 'v1alpha2',
+    kind: 'HTTPRoute',
+    title: 'HTTPRoute (K8s)'
+  },
+  {
     group: 'networking.istio.io',
     version: 'v1alpha3',
     kind: 'EnvoyFilter',
@@ -76,6 +88,8 @@ export const istioResources = [
 
 export const kialiIstioResources = {
   '/istio/wasmplugins':             '/extensions.istio.io~v1alpha1~WasmPlugin',
+  '/istio/k8sgateways':             '/gateway.networking.k8s.io~v1alpha2~Gateway',
+  '/istio/k8shttproutes':           '/gateway.networking.k8s.io~v1alpha2~HTTPRoute',
   '/istio/envoyfilters':            '/networking.istio.io~v1alpha3~EnvoyFilter',
   '/istio/destinationrules':        '/networking.istio.io~v1beta1~DestinationRule',
   '/istio/gateways':                '/networking.istio.io~v1beta1~Gateway',


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5026
K8s Gateway API objects are added with "(K8s)" title not to be messed with Istio objects.

![Screenshot from 2022-09-30 12-06-27](https://user-images.githubusercontent.com/604313/193247385-2cc3c500-f660-4383-96bd-a5714a095376.png)
![Screenshot from 2022-09-30 12-06-05](https://user-images.githubusercontent.com/604313/193247390-1f5fb33e-558a-4437-be6d-fd1c1af008db.png)
