### PR TITLE
Istio Config Details Service Mesh tab iFrame loads only config page with validations

### DIFF
--- a/plugin/console-extensions.json
+++ b/plugin/console-extensions.json
@@ -165,5 +165,140 @@
       },
       "component": { "$codeRef": "MeshTab" }
     }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "DestinationRule",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "Gateway",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "ServiceEntry",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "Sidecar",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "WorkloadEntry",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "networking.istio.io",
+        "kind": "WorkloadGroup",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "security.istio.io",
+        "kind": "AuthorizationPolicy",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "security.istio.io",
+        "kind": "PeerAuthentication",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
+  },
+  {
+    "type": "console.tab/horizontalNav",
+    "properties": {
+      "model": {
+        "group": "security.istio.io",
+        "kind": "RequestAuthentication",
+        "version": "v1beta1"
+      },
+      "page": {
+        "name": "Service Mesh",
+        "href": "ossmconsole"
+      },
+      "component": { "$codeRef": "MeshTab" }
+    }
   }
 ]

--- a/plugin/src/components/MeshTab.tsx
+++ b/plugin/src/components/MeshTab.tsx
@@ -78,7 +78,6 @@ const MeshTab = () => {
         const configType = configTypes[items[1].substring(items[1].lastIndexOf('~')+1)].toLowerCase();
         iFrameUrl = kialiUrl.baseUrl + '/console/namespaces/' + namespace + '/istio/' + configType + '/' + id + '?' + kioskUrl() + '&'
             + kialiUrl.token + '&duration=' + userProps.duration + '&timeRange=' + userProps.timeRange;
-        console.log("URL " + iFrameUrl)
     }
 
     // Projects is a special case that will forward the graph in the iframe

--- a/plugin/src/components/MeshTab.tsx
+++ b/plugin/src/components/MeshTab.tsx
@@ -10,6 +10,20 @@ const kialiTypes = {
     statefulsets: 'workloads',
 }
 
+const configTypes = {
+    DestinationRule: 'DestinationRules',
+    EnvoyFilter: 'EnvoyFilters',
+    Gateway: 'Gateways',
+    VirtualService: 'VirtualServices',
+    ServiceEntry: 'ServiceEntries',
+    Sidecar: 'Sidecars',
+    WorkloadEntry: 'WorkloadEntries',
+    WorkloadGroup: 'WorkloadGroups',
+    AuthorizationPolicy: 'AuthorizationPolicies',
+    PeerAuthentication: 'PeerAuthentications',
+    RequestAuthentication: 'RequestAuthentications',
+}
+
 const MeshTab = () => {
     const [kialiUrl, setKialiUrl] = React.useState({
         baseUrl: '',
@@ -58,9 +72,15 @@ const MeshTab = () => {
             id = id.substr(0, j);
         }
     }
-
     let iFrameUrl = kialiUrl.baseUrl + '/console/namespaces/' + namespace + '/' + type + '/' + id + '?' + kioskUrl() + '&'
         + kialiUrl.token + '&duration=' + userProps.duration + '&timeRange=' + userProps.timeRange;
+    if (!type) {
+        const configType = configTypes[items[1].substring(items[1].lastIndexOf('~')+1)].toLowerCase();
+        iFrameUrl = kialiUrl.baseUrl + '/console/namespaces/' + namespace + '/istio/' + configType + '/' + id + '?' + kioskUrl() + '&'
+            + kialiUrl.token + '&duration=' + userProps.duration + '&timeRange=' + userProps.timeRange;
+        console.log("URL " + iFrameUrl)
+    }
+
     // Projects is a special case that will forward the graph in the iframe
     if (items[1] === 'projects') {
         iFrameUrl = kialiUrl.baseUrl +  '/console/graph/namespaces?namespaces=' + id + '&' + kioskUrl() + '&' + kialiUrl.token


### PR DESCRIPTION
RFE https://github.com/kiali/openshift-servicemesh-plugin/issues/52

Istio config objects which have validations in Kiali side now have "Service Mesh" tab in Console.

![Screenshot from 2022-11-08 13-44-37](https://user-images.githubusercontent.com/604313/200567255-1a44e48c-b640-4ee9-9ae8-257ab4b338ad.png)
