### PR TITLE
[make] turn on profiler when running the operator via run-operator

### DIFF
--- a/make/Makefile.operator.mk
+++ b/make/Makefile.operator.mk
@@ -137,6 +137,8 @@ run-operator: install-crd install-cr get-ansible-operator
 	ALLOW_AD_HOC_OSSMCONSOLE_IMAGE="true" \
 	ANSIBLE_VERBOSITY_OSSMCONSOLE_KIALI_IO="1" \
 	ANSIBLE_DEBUG_LOGS="True" \
+	ANSIBLE_CALLBACK_WHITELIST="profile_tasks" \
+	ANSIBLE_CALLBACKS_ENABLED="profile_tasks" \
 	PROFILE_TASKS_TASK_OUTPUT_LIMIT="100" \
 	POD_NAMESPACE="does-not-exist" \
 	WATCH_NAMESPACE="" \


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/5950

When you run `make run-operator` and you see the operator finish reconciling, this kind of report should now appear in the output logs:

```
Tuesday 28 March 2023  08:23:53 -0400 (0:00:00.941)       0:00:00.990 ********* 
=============================================================================== 
Get all Kiali CRs ------------------------------------------------------- 0.94s
[.... and a whole bunch of other tasks and their times will be here...]
/home/jmazzite/source/kiali/kiali/operator/playbooks/kiali-new-namespace-detected.yml:18 
```