### PR TITLE
fix the typo in the new ansible setting name

### DIFF
--- a/operator/build/Dockerfile
+++ b/operator/build/Dockerfile
@@ -16,4 +16,4 @@ COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
-RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callback_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg
+RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callbacks_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg

--- a/operator/molecule/config-values-test/molecule.yml
+++ b/operator/molecule/config-values-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/operator/molecule/default/molecule.yml
+++ b/operator/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/operator/requirements.yml
+++ b/operator/requirements.yml
@@ -29,6 +29,8 @@
 #
 # To install that version locally, you can git clone the source via:
 #   git clone -b v<ansible version> --depth 1 https://github.com/ansible/ansible.git
+# and then set up your environment via:
+#   source ./ansible/hacking/env-setup -q
 
 collections:
 - name: kubernetes.core


### PR DESCRIPTION
The new setting name is `callbacks_enabled` (in the plural).

Also keep the deprecated name around since currently we are using an ansible version that doesn't know about the new one.

part of https://github.com/kiali/kiali/issues/4338