### PR TITLE
Use same prettier config as Kiali and core-ui projects

### DIFF
--- a/plugin/.prettierrc.json
+++ b/plugin/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "arrowParens": "avoid",
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/plugin/.prettierrc.yml
+++ b/plugin/.prettierrc.yml
@@ -1,3 +1,0 @@
-arrowParens: always
-singleQuote: true
-trailingComma: all


### PR DESCRIPTION
Hi @ferhoyos , I noticed a lot of prettier warning when I created an initial vscode project for ossmc.  Not sure if it was intentional to have a different prettier config for OSSMC, but if not let's use the same as Kiali and core-ui.  Otherwise we should do a big reformat of the OSSMC repo.