### PR TITLE
do not tell user to install-crd - OLM is responsible for it and will install it

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here's a tl;dr summary to get the operator and plugin installed in your cluster.
 
 1. First run `make cluster-status` to expose the internal image registry and get the podman command needed to log into the internal image registry.
 2. Run the podman login command that will log into the internal image registry.
-3. Build, push, and deploy the operator and plugin by running `make cluster-push operator-create install-crd install-cr`
+3. Build, push, and deploy the operator and plugin by running `make cluster-push operator-create install-cr`
 
 When you are finished and you want to uninstall the operator and plugin, run `make operator-delete`.
 


### PR DESCRIPTION
The instructions are incorrect - the user should not "install-crd" here. When installing the operator via OLM, OLM is responsible for installing the CRD - when OLM deploys the operator, it will also deploy the CRDs associated with the operator.

Note that the `install-cr` make target will wait for the CRD to be deployed. So after `operator-create`, OLM will take some time but eventually deploy the operator and then its CRD. The `install-cr` make target will wait until that CRD is deployed before it creates the actual CR.