### PR TITLE
no need for build-plugin-image to call build-plugin.

### DIFF
--- a/make/Makefile.plugin.mk
+++ b/make/Makefile.plugin.mk
@@ -23,7 +23,7 @@ build-plugin:
 	cd ${PLUGIN_DIR} && yarn install --network-timeout 7200000 && yarn build
 
 ## build-plugin-image: Builds the plugin and its container image.
-build-plugin-image: build-plugin
+build-plugin-image:
 	${DORP} build --build-arg VERSION_PLUGIN="${VERSION}" --build-arg COMMIT_HASH="${COMMIT_HASH}" -t ${PLUGIN_QUAY_TAG} ${PLUGIN_DIR}
 
 ## push-plugin-image: Pushes the plugin container image to quay.io.


### PR DESCRIPTION
The Dockerfile runs the yarn install in the container already. It is pointless to run it locally (which is what build-plugin does). We need the yarn install run inside the plugin during the docker build, which is what this still does.