### PR TITLE
Update to Node 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,15 +5,15 @@ on:
   push:
     branches: [main, "^v\\d+\\.\\d+$"]
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.adoc'
+    - 'docs/**'
+    - '**/*.md'
+    - '**/*.adoc'
   pull_request:
     branches: [main, "^v\\d+\\.\\d+$"]
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.adoc'
+    - 'docs/**'
+    - '**/*.md'
+    - '**/*.adoc'
 
 jobs:
   initialize:
@@ -59,7 +59,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: "14"
+        node-version: "18"
         cache: yarn
         cache-dependency-path: plugin/yarn.lock
     - name: Build image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,12 +56,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ inputs.build_branch }}
-    - name: Setup node
-      uses: actions/setup-node@v3
-      with:
-        node-version: "18"
-        cache: yarn
-        cache-dependency-path: plugin/yarn.lock
+
     - name: Build image
       run: |
         make -e CONTAINER_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile) build-plugin-image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,15 +5,15 @@ on:
   push:
     branches: [main, "^v\\d+\\.\\d+$"]
     paths-ignore:
-    - 'docs/**'
-    - '**/*.md'
-    - '**/*.adoc'
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.adoc'
   pull_request:
     branches: [main, "^v\\d+\\.\\d+$"]
     paths-ignore:
-    - 'docs/**'
-    - '**/*.md'
-    - '**/*.adoc'
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.adoc'
 
 jobs:
   initialize:

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM  registry.access.redhat.com/ubi8/nodejs-16 AS build
+FROM  registry.access.redhat.com/ubi8/nodejs-18 AS build
 
 USER root
 RUN command -v yarn || npm i -g yarn

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -128,6 +128,10 @@
     "nth-check": "^2.0.1",
     "postcss": "^8.4.12"
   },
+  "engines": {
+    "node": ">=18.0.0",
+    "yarn": ">=1.0.0"
+  },
   "consolePlugin": {
     "name": "ossmconsole",
     "version": "0.1.0",


### PR DESCRIPTION
Update of github workflows to Node 18 and set node engine in package.json to node >= 18

Closes #204.

**PR Testing**
Check that OSSMC is built and deployed correctly with Node 18.