### PR TITLE
update consolePlugin.version in package.json on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,8 +215,9 @@ jobs:
         sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
         # UI version
-        jq -r '.version |= "${RELEASE_VERSION:1}"' plugin/package.json > plugin/package.json.tmp
+        jq -r ".version |= \"${RELEASE_VERSION:1}\" | .consolePlugin.version |= \"${RELEASE_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
+        cat plugin/package.json
 
     - name: Build and push images
       run: |
@@ -265,8 +266,9 @@ jobs:
       run: |
         sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
 
-        jq -r ".version |= \"${NEXT_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
+        jq -r ".version |= \"${NEXT_VERSION:1}\" | .consolePlugin.version |= \"${NEXT_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
+        cat plugin/package.json
 
         git add Makefile plugin/package.json
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -134,7 +134,7 @@
   },
   "consolePlugin": {
     "name": "ossmconsole",
-    "version": "0.1.0",
+    "version": "0.5.0",
     "displayName": "OpenShift Service Mesh Console",
     "description": "Provides Service Mesh/Istio Observability",
     "exposedModules": {


### PR DESCRIPTION
fixes: https://github.com/kiali/openshift-servicemesh-plugin/issues/206

This PR will update the release workflow so it automatically updates the plugin/package.json file's consolePlugin.version field (it was not getting updated previously - it is still stuck on 0.1.0).

This PR also manually updates the consolePlugin.version field so it is up to date (and matches the version field). This is just so it is consistent and matches the actual current version (0.5.0).  With the change in the release workflow that this PR is introducing, we will not have to manually update this consolePlugin.version field anymore.