### PR TITLE
Add GLOBAL_SCROLLBAR environment variable

### DIFF
--- a/plugin/.env.development
+++ b/plugin/.env.development
@@ -18,3 +18,6 @@ API_PROXY=http://localhost:3001
 
 # Prefix added to all CSS classnames to fulfill Openshift plugin requirements
 CSS_PREFIX=kiali
+
+# Let Kiali knows if the global scrollbar is enabled or not
+GLOBAL_SCROLLBAR=true

--- a/plugin/.env.production
+++ b/plugin/.env.production
@@ -19,3 +19,6 @@ API_PROXY=/api/proxy/plugin/ossmconsole/kiali
 
 # Prefix added to all CSS classnames to fulfill Openshift plugin requirements
 CSS_PREFIX=ossmc_plugin_
+
+# Let Kiali knows if the global scrollbar is enabled or not
+GLOBAL_SCROLLBAR=true

--- a/plugin/webpack.config.ts
+++ b/plugin/webpack.config.ts
@@ -91,7 +91,8 @@ const config: Configuration = {
     new ConsoleRemotePlugin(),
     new DefinePlugin({
       'process.env.API_PROXY': JSON.stringify(process.env.API_PROXY),
-      'process.env.CSS_PREFIX': JSON.stringify(process.env.CSS_PREFIX)
+      'process.env.CSS_PREFIX': JSON.stringify(process.env.CSS_PREFIX),
+      'process.env.GLOBAL_SCROLLBAR': JSON.stringify(process.env.GLOBAL_SCROLLBAR)
     }),
     new NodePolyfillPlugin(),
     new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
Add GLOBAL_SCROLLBAR environment variable to let Kiali knows if the global scrollbar is enabled (like Openshift) or not (like Kiali standalone application).

Do not merge this PR until https://github.com/kiali/kiali/pull/6607 is copied into OSSMC repository.

Closes #208 