### PR TITLE
Set local Openshift Console version to match OCP version

### DIFF
--- a/plugin/start-console.sh
+++ b/plugin/start-console.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
+OPENSHIFT_VERSON=$(oc version | grep "Server Version: " | awk '{print $3}' | cut -d. -f-2)
+CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:$OPENSHIFT_VERSON"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 
 echo "Starting local OpenShift console..."


### PR DESCRIPTION
Currently, Openshift console deployed locally (via `start-console.sh`) gets the latest version from quay.io. The issue is that the latest version of Openshift console (4.16) loads Patternfly 5, which is incompatible with last OCP released (4.14) that loads Patternfly 4.

To solve the issue I have calculated OCP server version installed in the local development environment and loads the corresponding Openshift Console version.