### PR TITLE
Enable OSSMC plugin if no other plugins are installed in Openshift

### DIFF
--- a/make/Makefile.plugin.mk
+++ b/make/Makefile.plugin.mk
@@ -45,7 +45,12 @@ undeploy-plugin: .ensure-oc-login disable-plugin
 
 ## enable-plugin: Enables the plugin within the OpenShift Console.
 enable-plugin: .ensure-oc-login
-	${OC} patch consoles.operator.openshift.io cluster --type=json -p '[{"op":"add","path":"/spec/plugins/-","value":"ossmconsole"}]'
+	@if [ "$$(${OC} get consoles.operator.openshift.io cluster -o json | jq '.spec.plugins')" == "null" ]; then ${OC} patch consoles.operator.openshift.io cluster --type=json -p '[{"op":"add","path":"/spec/plugins","value":[]}]'; fi
+	@if [ "$$(${OC} get consoles.operator.openshift.io cluster -o json | jq '.spec.plugins | index("ossmconsole")')" == "null" ]; then \
+	  ${OC} patch consoles.operator.openshift.io cluster --type=json -p '[{"op":"add","path":"/spec/plugins/-","value":"ossmconsole"}]'; \
+	else \
+	  echo OSSMC plugin is already enabled; \
+	fi
 
 ## disable-plugin: Disables the plugin within the OpenShift Console.
 disable-plugin: .ensure-oc-login


### PR DESCRIPTION
If no other plugins are installed in Openshift, command `make enable-plugin` fails because `plugin` field is not specified.

This PR first creates `plugin` field if not present. Then add `ossmconsole` entry to `plugin` field, showing a console message if the plugin is already enabled.