### PR TITLE
Ensure oc login before starting plugin console

### DIFF
--- a/plugin/start-console.sh
+++ b/plugin/start-console.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+cd ..
+make .ensure-oc-login
+
+cd plugin
 OPENSHIFT_VERSON=$(oc version | grep "Server Version: " | awk '{print $3}' | cut -d. -f-2)
 CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:$OPENSHIFT_VERSON"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}


### PR DESCRIPTION
Suggested by @jmazzitelli in https://github.com/kiali/openshift-servicemesh-plugin/pull/232#discussion_r1445131165,  `yarn start-console` comand now throws an error if developer has not login into any OCP.