### PR TITLE
Add error page when Istio Config List is not loaded correctly

### DIFF
--- a/plugin/src/openshift/components/ErrorPage.tsx
+++ b/plugin/src/openshift/components/ErrorPage.tsx
@@ -41,7 +41,7 @@ const messageStyle = kialiStyle({
   fontFamily: 'var(--pf-global--FontFamily--sans-serif)'
 });
 
-export const ErrorPage: React.FC<ErrorPageProps> = ({ title = 'Error', message = 'Unexpected error occurrs' }) => {
+export const ErrorPage: React.FC<ErrorPageProps> = ({ title = 'Error', message = 'Unexpected error occurred' }) => {
   return (
     <>
       <h1 className={headerStyle}>Error</h1>

--- a/plugin/src/openshift/components/ErrorPage.tsx
+++ b/plugin/src/openshift/components/ErrorPage.tsx
@@ -4,13 +4,13 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { NestedCSSProperties } from 'typestyle/lib/types';
 
 export interface OSSMCError {
-  title: string;
-  message: string;
+  title?: string;
+  message?: string;
 }
 
 interface ErrorPageProps {
-  title: string;
-  message: string;
+  title?: string;
+  message?: string;
 }
 
 const h1Style: NestedCSSProperties = {
@@ -41,7 +41,7 @@ const messageStyle = kialiStyle({
   fontFamily: 'var(--pf-global--FontFamily--sans-serif)'
 });
 
-export const ErrorPage: React.FC<ErrorPageProps> = ({ title, message }) => {
+export const ErrorPage: React.FC<ErrorPageProps> = ({ title = 'Error', message = 'Unexpected error occurrs' }) => {
   return (
     <>
       <h1 className={headerStyle}>Error</h1>

--- a/plugin/src/openshift/components/ErrorPage.tsx
+++ b/plugin/src/openshift/components/ErrorPage.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { PFColors } from 'components/Pf/PfColors';
+import { kialiStyle } from 'styles/StyleUtils';
+import { NestedCSSProperties } from 'typestyle/lib/types';
+
+export interface OSSMCError {
+  title: string;
+  message: string;
+}
+
+interface ErrorPageProps {
+  title: string;
+  message: string;
+}
+
+const h1Style: NestedCSSProperties = {
+  fontFamily: 'var(--pf-global--FontFamily--heading--sans-serif)',
+  fontWeight: 'var(--pf-global--FontWeight--normal)',
+  fontSize: 'var(--pf-global--FontSize--2xl)',
+  lineHeight: 'var(--pf-global--LineHeight--sm)'
+};
+
+const headerStyle = kialiStyle({
+  ...h1Style,
+  padding: '1.5rem',
+  borderBottom: `1px solid ${PFColors.BorderColor100}`
+});
+
+const errorStyle = kialiStyle({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center'
+});
+
+const titleStyle = kialiStyle({
+  ...h1Style,
+  margin: '1rem 1.5rem 1.5rem'
+});
+
+const messageStyle = kialiStyle({
+  fontFamily: 'var(--pf-global--FontFamily--sans-serif)'
+});
+
+export const ErrorPage: React.FC<ErrorPageProps> = ({ title, message }) => {
+  return (
+    <>
+      <h1 className={headerStyle}>Error</h1>
+      <div className={errorStyle}>
+        <h1 className={titleStyle}>{title}</h1>
+        <div className={messageStyle}>{message}</div>
+      </div>
+    </>
+  );
+};

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -28,7 +28,6 @@ import { kialiStyle } from 'styles/StyleUtils';
 import { store } from 'store/ConfigStore';
 import cssVariables from 'styles/variables.module.scss';
 
-import '@patternfly/patternfly/patternfly.css';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/dist/themes/light-border.css';
 

--- a/plugin/src/openshift/pages/IstioConfigListPage.tsx
+++ b/plugin/src/openshift/pages/IstioConfigListPage.tsx
@@ -184,8 +184,8 @@ const IstioConfigListPage = () => {
         .then(response => {
           return toIstioItems(response.data);
         })
-        .catch(error => {
-          setLoadError({ title: error.response.statusText, message: error.response.data.error });
+        .catch((error: API.ApiError) => {
+          setLoadError({ title: error.response?.statusText, message: error.response?.data.error });
           return [];
         });
     } else {
@@ -203,8 +203,8 @@ const IstioConfigListPage = () => {
           });
           return istioItems;
         })
-        .catch(error => {
-          setLoadError({ title: error.response.statusText, message: error.response.data.error });
+        .catch((error: API.ApiError) => {
+          setLoadError({ title: error.response?.statusText, message: error.response?.data.error });
           return [];
         });
     }


### PR DESCRIPTION
Istio Config List has project dropdown handled by Openshift to select target project. Problem occurs when OSSMC does not have access to such project (configured in Kiali server - `accessible_namespaces` field). Since that dropdown is handled by Openshift (not by OSSMC) it is not possible to filter that dropdown to show only accessible projects (done in other pages like Overview and Graph).

Only thing that we can do is to show a proper error message indicating that this namespace is not accessible:
![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/784faa52-2d68-4ac3-895c-be9612f93021)

Also shows any other issue that could happen on Istio Object list load (e.g., the project is not found):

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/1ded1114-1652-4e9e-8430-f33a8fc58b57)

### Steps to test this PR
1. Modify `accessible_namespace` value of Kiali server to exclude some namespace:
Example: 
```
deployment:
  accessible_namespaces: ["istio-system"]
```
2. Go to openshift dashboard and click on `Istio Config List` within `Service Mesh`  section in the navigation menu
3. Unauthorized error message should appear.
4. To see Not Found error message, just go to the url in the browser and modify it with a project/namespace that does not exist (e.g., 'test' or 'aaaa')

### Issue Reference
Fixes #239 