### PR TITLE
Generate Cypress XML report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ plugin/src/kiali/**/*.css
 plugin/src/kiali/**/*.css.map
 !plugin/src/kiali/components/IstioWizards/Slider/styles/default.css
 
+# Cypress
+plugin/cypress/results

--- a/plugin/.cypress-cucumber-preprocessorrc.json
+++ b/plugin/.cypress-cucumber-preprocessorrc.json
@@ -1,7 +1,0 @@
-{
-    "stepDefinitions": [
-        "cypress/e2e/[filepath]/**/*.{js,ts}",
-        "cypress/e2e/[filepath].{js,ts}",
-        "cypress/support/step_definitions/**/*.{js,ts}"
-    ]
-}

--- a/plugin/cypress.config.ts
+++ b/plugin/cypress.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from 'cypress';
-import { getAuthStrategy } from './cypress/plugins/setup';
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
-import createBundler from "@bahmutov/cypress-esbuild-preprocessor";
-import { createEsbuildPlugin } from "@badeball/cypress-cucumber-preprocessor/esbuild";
+import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
+import { createEsbuildPlugin } from '@badeball/cypress-cucumber-preprocessor/esbuild';
 
 export default defineConfig({
   viewportWidth: 1920,
@@ -15,13 +14,13 @@ export default defineConfig({
   responseTimeout: 15000,
   fixturesFolder: 'cypress/fixtures',
   chromeWebSecurity: true, // needs to disabled for cross origin requests
-  screenshotsFolder: "results/screenshots",
-  videosFolder: "results/videos",
+  screenshotsFolder: 'cypress/results/screenshots',
+  videosFolder: 'cypress/results/videos',
   // videoUploadOnPasses: false, // this is not supported in cypress 13+, TODO add this back to config
 
   env: {
-    OC_CLUSTER_USER: "jenkins", // default value for jenkins
-    OC_IDP: "my_htpasswd_provider", // default value for jenkins, can vary based on cluster setup
+    OC_CLUSTER_USER: 'jenkins', // default value for jenkins
+    OC_IDP: 'my_htpasswd_provider', // default value for jenkins, can vary based on cluster setup
     'cypress-react-selector': {
       root: '#root'
     },
@@ -39,9 +38,9 @@ export default defineConfig({
       await addCucumberPreprocessorPlugin(on, config);
 
       on(
-        "file:preprocessor",
+        'file:preprocessor',
         createBundler({
-          plugins: [createEsbuildPlugin(config)],
+          plugins: [createEsbuildPlugin(config)]
         })
       );
 
@@ -52,5 +51,5 @@ export default defineConfig({
     },
     specPattern: '**/*.feature',
     supportFile: 'cypress/support/index.ts'
-}
+  }
 });

--- a/plugin/cypress/reporter-config.json
+++ b/plugin/cypress/reporter-config.json
@@ -1,0 +1,8 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "cypress/results/results-[hash].xml",
+    "testCaseSwitchClassnameAndName": true,
+    "jenkinsMode": true
+  }
+}

--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -10,25 +10,25 @@
 // ***********************************************
 
 declare global {
-    namespace Cypress {
-        interface Chainable {
-            login(OC_CLUSTER_USER: string, OC_CLUSTER_PASS: string, OC_IDP: string): Chainable<void>
-        }
+  namespace Cypress {
+    interface Chainable {
+      login(OC_CLUSTER_USER: string, OC_CLUSTER_PASS: string, OC_IDP: string): Chainable<void>;
     }
+  }
 }
 
 Cypress.Commands.add('login', (OC_CLUSTER_USER, OC_CLUSTER_PASS, OC_IDP) => {
-    const user = OC_CLUSTER_USER || Cypress.env('OC_CLUSTER_USER')
-    const password = OC_CLUSTER_PASS || Cypress.env('OC_CLUSTER_PASS')
-    const idp = OC_IDP || Cypress.env('OC_IDP')
+  const user = OC_CLUSTER_USER || Cypress.env('OC_CLUSTER_USER');
+  const password = OC_CLUSTER_PASS || Cypress.env('OC_CLUSTER_PASS');
+  const idp = OC_IDP || Cypress.env('OC_IDP');
 
-    cy.visit('/').then(() => {
-        cy.log('OC_IDP: ', typeof (idp), JSON.stringify(idp))
-        if (idp != undefined) {
-            cy.get('.pf-c-button').contains(idp).click()
-        }
-        cy.get('#inputUsername').type(user)
-        cy.get('#inputPassword').type(password)
-        cy.get('button[type="submit"]').click();
-    })
-})
+  cy.visit('/').then(() => {
+    cy.log('OC_IDP: ', typeof idp, JSON.stringify(idp));
+    if (idp != undefined) {
+      cy.get('.pf-c-button').contains(idp).click();
+    }
+    cy.get('#inputUsername').clear().type(user);
+    cy.get('#inputPassword').clear().type(password);
+    cy.get('button[type="submit"]').click();
+  });
+});

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -14,7 +14,7 @@
     "start-console": "./start-console.sh",
     "cypress": "cypress open",
     "cypress:run": "cypress run $REPORTER -e TAGS=\"@install\" && cypress run $REPORTER -e TAGS=\"not @install and not @uninstall\" && cypress run $REPORTER -e TAGS=\"@uninstall\"",
-    "cypress:run:reports": "REPORTER='--reporter cypress-multi-reporters --reporter-options configFile=cypress/reporter-config.json' npm run cypress:run ",
+    "cypress:run:junit": "REPORTER='--reporter cypress-multi-reporters --reporter-options configFile=cypress/reporter-config.json' npm run cypress:run ",
     "cypress:delete:reports": "rm cypress/results/* || true",
     "cypress:combine:reports": "jrm cypress/results/combined-report.xml \"cypress/results/*.xml\"",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -12,8 +12,11 @@
     "build:dev": "yarn clean && sh -ac '. ./.env.development; yarn ts-node node_modules/.bin/webpack'",
     "start": "sh -ac '. ./.env.development; yarn ts-node node_modules/.bin/webpack serve'",
     "start-console": "./start-console.sh",
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run -e TAGS=\"@install\" && cypress run -e TAGS=\"not @install and not @uninstall\" && cypress run -e TAGS=\"@uninstall\"",
+    "cypress": "cypress open",
+    "cypress:run": "cypress run $REPORTER -e TAGS=\"@install\" && cypress run $REPORTER -e TAGS=\"not @install and not @uninstall\" && cypress run $REPORTER -e TAGS=\"@uninstall\"",
+    "cypress:run:reports": "REPORTER='--reporter cypress-multi-reporters --reporter-options configFile=cypress/reporter-config.json' npm run cypress:run ",
+    "cypress:delete:reports": "rm cypress/results/* || true",
+    "cypress:combine:reports": "jrm cypress/results/combined-report.xml \"cypress/results/*.xml\"",
     "i18n": "i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c i18next-parser.config.js",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'",
     "lint": "eslint --ext js,ts,tsx src",
@@ -133,6 +136,14 @@
   "engines": {
     "node": ">=18.0.0",
     "yarn": ">=1.0.0"
+  },
+  "cypress-cucumber-preprocessor": {
+    "stepDefinitions": [
+      "cypress/e2e/[filepath]/**/*.{js,ts}",
+      "cypress/e2e/[filepath].{js,ts}",
+      "cypress/support/step_definitions/**/*.{js,ts}"
+    ],
+    "filterSpecs": true
   },
   "consolePlugin": {
     "name": "ossmconsole",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -22,9 +22,9 @@
     "lint": "eslint --ext js,ts,tsx src",
     "lint:precommit": "if git diff --name-only HEAD | grep -E '\\.tsx?$'; then npm run lint; else true; fi",
     "lint:fix": "eslint --ext js,ts,tsx --fix src",
-    "prettier": "prettier --write \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\"",
+    "prettier": "prettier --write \"**/*.{ts,tsx,scss,json}\"",
     "prepare": "cd .. && husky install plugin/.husky",
-    "pre-commit": "yarn run pretty-quick --staged --pattern \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\" && npm run lint:precommit"
+    "pre-commit": "yarn run pretty-quick --staged --no-restage --bail --pattern \"**/*.{ts,tsx,scss,json}\" && npm run lint:precommit"
   },
   "dependencies": {
     "@openshift-console/dynamic-plugin-sdk": "^0.0.19",


### PR DESCRIPTION
### Describe the change

This PR allows the generation of XML reports of cypress tests run. These reports are useful to analyze test results of CI/CD cypress test executions.

Besides, I have modified prettier configuration to include cypress tests in the formatter process