### PR TITLE
Align release github action with Kiali

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,7 @@ name: Release
 on:
   schedule:
   # Every Monday at 07:00 (UTC)
-  - cron: '00 7 * * MON'
-
+  - cron: "00 7 * * MON"
   workflow_dispatch:
     inputs:
       plugin_quay_repository:
@@ -24,10 +23,9 @@ jobs:
       branch_version: ${{ env.branch_version }}
       next_version: ${{ env.next_version }}
       plugin_quay_tag: ${{ env.plugin_quay_tag }}
-      plugin_quay_repo: ${{ env.plugin_quay_repo }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.ref_name }}
 
@@ -71,7 +69,8 @@ jobs:
     - name: Determine release type
       id: release_type
       run: |
-        if [ -z "${{ github.event.inputs.release_type }}" ];
+        echo ${{ github.ref_name }}
+        if [[ "${{ github.ref_name }}" == "main" ]];
         then
           DO_RELEASE=$(python minor.py)
           if [[ $DO_RELEASE == "1" ]]
@@ -81,7 +80,7 @@ jobs:
             echo "release_type=skip" >> $GITHUB_ENV
           fi
         else
-          echo "release_type=${{ github.event.inputs.release_type }}" >> $GITHUB_ENV
+          echo "release_type=patch" >> $GITHUB_ENV
         fi
 
     - name: Determine release version
@@ -143,10 +142,9 @@ jobs:
           PLUGIN_QUAY_REPO="${{ github.event.inputs.plugin_quay_repository }}"
         fi
 
-        PLUGIN_QUAY_TAG="$PLUGIN_QUAY_REPO:$RELEASE_VERSION"
+        PLUGIN_QUAY_TAG="$PLUGIN_QUAY_REPO:$RELEASE_VERSION $PLUGIN_QUAY_REPO:$BRANCH_VERSION"
 
         echo "plugin_quay_tag=$PLUGIN_QUAY_TAG" >> $GITHUB_ENV
-        echo "plugin_quay_repo=$PLUGIN_QUAY_REPO" >> $GITHUB_ENV
 
     - name: Cleanup
       run: rm bump.py minor.py
@@ -176,9 +174,9 @@ jobs:
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        ref: ${{ github.ref_name }}
 
     - name: Set version to release
       run: |
@@ -188,7 +186,6 @@ jobs:
         # UI version
         jq -r ".version |= \"${RELEASE_VERSION:1}\" | .consolePlugin.version |= \"${RELEASE_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
-        cat plugin/package.json
 
     - name: Build and push images
       run: |
@@ -223,7 +220,6 @@ jobs:
 
         jq -r ".version |= \"${NEXT_VERSION:1}\" | .consolePlugin.version |= \"${NEXT_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
-        cat plugin/package.json
 
         git add Makefile plugin/package.json
 


### PR DESCRIPTION
### Describe the change

Now that openshift-servicemesh-plugin follows same release cadence as kiali (one minor release every 3 weeks and branch creation with that release), I have aligned release github action with kiali repository one to determine what type of release needs:

- If the branch selected is `main` -> Minor version (e.g., from 1.79 to 1.80)
- If the branch selected is a release version -> Patch version (e.g. from 1.79.0 to 1.79.1 if branch selected is v1.79

Currently patch versions are not released because OSSMC always embeds 1.73 version due to PF limitation. When the plugin is adapted to PF5 we will have to plan a release schedule to match Kiali version with OSSMC version (I mean Kiali code embedded in OSSMC).

### Issue reference
Closes #229 