### PR TITLE
Fix istio config href in overview page

### DIFF
--- a/plugin/src/openshift/utils/KialiIntegration.ts
+++ b/plugin/src/openshift/utils/KialiIntegration.ts
@@ -55,10 +55,14 @@ export const useInitKialiListeners = () => {
 
         if (webParamsIndex > -1) {
           const nsParamIndex = kialiAction.indexOf('namespaces=', webParamsIndex);
-          // It assumes that the 'namespaces=' will not be added alone as a param
+
           // Under the plugin it will be used for a single namespace
-          // TODO additional validations should be added to this parsing logic
-          const endNsParamIndex = kialiAction.indexOf('&', nsParamIndex);
+          let endNsParamIndex = kialiAction.indexOf('&', nsParamIndex);
+          // In case that the 'namespaces=' is added alone as a param
+          if (endNsParamIndex === -1) {
+            endNsParamIndex = kialiAction.length;
+          }
+
           const namespace = kialiAction.substring(nsParamIndex + 'namespaces='.length, endNsParamIndex);
           istioConfigUrl += '/ns/' + namespace + '/istio';
         } else {


### PR DESCRIPTION
Modify OSSMC URL redirection to fix broken istio config href in the Overview page

Steps to test the PR:
- Open OSSMC in OCP
- Navigate into Service Mesh > Overview
- Click on symbol next to "Istio Config" label in istio-system card

OSSMC plugin should redirect to Istio Config page of that project/namespace

Since this bug has high priority, I have created different issue to track Cypress tests of this feature (#254)

Fixes #251 