### PR TITLE
free disk space and set max-parallelism=1 to get the github action to build

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,6 +56,14 @@ jobs:
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
+    # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
+    - name: Print disk space before
+      run: df -h
+    - name: Free up space
+      run: rm -rf /opt/hostedtoolcache
+    - name: Print disk space after
+      run: df -h
+
     - name: Build and push plugin image
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,6 +187,14 @@ jobs:
         jq -r ".version |= \"${RELEASE_VERSION:1}\" | .consolePlugin.version |= \"${RELEASE_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
 
+    # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
+    - name: Print disk space before
+      run: df -h
+    - name: Free up space
+      run: rm -rf /opt/hostedtoolcache
+    - name: Print disk space after
+      run: df -h
+
     - name: Build and push images
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -201,6 +201,12 @@ jobs:
 
         make build-push-plugin-multi-arch
 
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+
+        git config user.name 'kiali-bot'
+
     - name: Create tag
       run: |
         git add Makefile plugin/package.json

--- a/make/Makefile.plugin.mk
+++ b/make/Makefile.plugin.mk
@@ -130,7 +130,7 @@ prepare-dev-env: .determine-kiali-url
 .ensure-buildx-builder: .ensure-docker-buildx
 	@if ! docker buildx inspect ossmconsole-builder > /dev/null 2>&1; then \
 	  echo "The buildx builder instance named 'ossmconsole-builder' does not exist. Creating one now."; \
-	  if ! docker buildx create --name=ossmconsole-builder --driver-opt=image=moby/buildkit:v0.8.0; then \
+	  if ! docker buildx create --name=ossmconsole-builder --driver-opt=image=moby/buildkit:v0.12.5 --config ./make/buildkitd.toml --use; then \
 	    echo "Failed to create the buildx builder 'ossmconsole-builder'"; \
 	    exit 1; \
 	  fi \

--- a/make/buildkitd.toml
+++ b/make/buildkitd.toml
@@ -1,0 +1,2 @@
+[worker.oci]
+  max-parallelism = 1


### PR DESCRIPTION
Our builds are failing on GitHub Actions because its running out of disk space.

Following the tips [here](https://github.com/orgs/community/discussions/25678#discussioncomment-5242449), this PR is removing a large 9GB directory that we should not need. I'm testing on my own fork to see if this build succeeds. If so, we can merge this and try another release. If not, well, this PR might still be useful in the future in case we need to save 9GB more disk space. 

