### PR TITLE
start release build at 1am

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   schedule:
-  # Every Monday at 07:00 (UTC)
-  - cron: "00 7 * * MON"
+  # Every Monday at 01:00 (UTC) - this action takes several hours to complete
+  - cron: "00 1 * * MON"
   workflow_dispatch:
     inputs:
       plugin_quay_repository:


### PR DESCRIPTION
This is a temp fix to https://github.com/kiali/kiali/issues/6865 - read that issue to find out why this is being done.