### PR TITLE
Adapt Cypress tests to OpenShift 4.15

### DIFF
--- a/plugin/cypress/e2e/sidebar-navigation.ts
+++ b/plugin/cypress/e2e/sidebar-navigation.ts
@@ -1,67 +1,94 @@
-import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor";
+import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { getApiProxy } from '../support/utils';
+
+Before(() => {
+  // This prevents cypress from stopping on errors unrelated to the tests.
+  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
+  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
+  cy.on('uncaught:exception', (err, _runnable, promise) => {
+    // when the exception originated from an unhandled promise
+    // rejection, the promise is provided as a third argument
+    // you can turn off failing the test in this case
+    if (promise || err.message.includes('MobX')) {
+      return false;
+    }
+    // we still want to ensure there are no other unexpected
+    // errors, so we let them fail the test
+  });
+});
 
 When('user clicks on the Service Mesh icon in the left navigation bar', () => {
-    cy.get('button.pf-c-nav__link').contains('Service Mesh').click().then(() => {
-        cy.get('ul.pf-c-nav__list').should('be.visible')
-    })
+  cy.get('button[class$="c-nav__link"]')
+    .contains('Service Mesh')
+    .click()
+    .then(() => {
+      cy.get('ul[class$="c-nav__list"]').should('be.visible');
+    });
 });
 
 When('cypress intercept hooks for sidebar are registered', () => {
-    cy.intercept('/api/proxy/plugin/ossmconsole/kiali/api/namespaces/istio-system/metrics?*').as('metricsRequest')
-    cy.intercept('/api/proxy/plugin/ossmconsole/kiali/api/istio/status?*').as('overviewRequest')
-    cy.intercept('/api/proxy/plugin/ossmconsole/kiali/api/namespaces').as('istioConfigRequest')
+  const apiProxy = getApiProxy();
+  cy.intercept(`${apiProxy}/api/namespaces/istio-system/metrics?*`).as('metricsRequest');
+  cy.intercept(`${apiProxy}/api/istio/status?*`).as('overviewRequest');
+  cy.intercept(`${apiProxy}/api/namespaces`).as('istioConfigRequest');
 });
 
 Then('buttons for Overview, Graph and Istio Config are displayed', () => {
-    cy.waitForReact(5000, '#app', 'node_modules/resq/dist/index.js'); // Manually passing in the resq module path
-    cy.reload(true) // force reload to make sure OSSMC is loaded 
-    cy.get('a[data-test="nav"].pf-c-nav__link').contains('Overview')
-    cy.get('a[data-test="nav"].pf-c-nav__link').contains('Graph')
-    cy.get('a[data-test="nav"].pf-c-nav__link').contains('Istio Config')
+  cy.waitForReact(5000, '#app', 'node_modules/resq/dist/index.js'); // Manually passing in the resq module path
+  cy.reload(true); // force reload to make sure OSSMC is loaded
+  cy.get('a[data-test="nav"][class$="c-nav__link"]').contains('Overview');
+  cy.get('a[data-test="nav"][class$="c-nav__link"]').contains('Graph');
+  cy.get('a[data-test="nav"][class$="c-nav__link"]').contains('Istio Config');
 });
 
 Then('user is redirected to the OSSMC {string} page', (hrefName: string) => {
-    switch (hrefName) {
-        case 'Overview':
-            cy.get('a[href*="/ossmconsole/overview"]').click().then(() => {
-                cy.url().should('include', "/ossmconsole/overview")
-            })
-            break;
-        case 'Graph':
-            cy.get('a[href*="/ossmconsole/graph"]').click().then(() => {
-                cy.url().should('include', "/ossmconsole/graph")
-            })
-            break;
-        case 'Istio Config':
-            cy.get('a[href*="/k8s/all-namespaces/istio"]').click().then(() => {
-                cy.url().should('include', "/k8s/all-namespaces/istio")
-            })
-            break;
-    }
+  switch (hrefName) {
+    case 'Overview':
+      cy.get('a[href*="/ossmconsole/overview"]')
+        .click()
+        .then(() => {
+          cy.url().should('include', '/ossmconsole/overview');
+        });
+      break;
+    case 'Graph':
+      cy.get('a[href*="/ossmconsole/graph"]')
+        .click()
+        .then(() => {
+          cy.url().should('include', '/ossmconsole/graph');
+        });
+      break;
+    case 'Istio Config':
+      cy.get('a[href*="/k8s/all-namespaces/istio"]')
+        .click()
+        .then(() => {
+          cy.url().should('include', '/k8s/all-namespaces/istio');
+        });
+      break;
+  }
 });
 
 Then('user sees memory and cpu charts from Kiali', () => {
-    cy.wait('@metricsRequest').then(() => {
-        cy.get('[data-test="memory-chart"]').should('be.visible')
-        cy.get('[data-test="cpu-chart"]').should('be.visible')
-    })
+  cy.wait('@metricsRequest').then(() => {
+    cy.get('[data-test="memory-chart"]').should('be.visible');
+    cy.get('[data-test="cpu-chart"]').should('be.visible');
+  });
 });
 
 Then('user sees istio-system overview card', () => {
-    cy.wait('@overviewRequest').then(() => {
-        cy.get('h5').contains('istio-system').should('be.visible')
-    })
+  cy.wait('@overviewRequest').then(() => {
+    cy.get('h5').contains('istio-system').should('be.visible');
+  });
 });
 
 Then('user sees Graph page elements from Kiali', () => {
-    cy.get('[data-test="namespace-dropdown"]').should('be.visible')
-    // not able to find correct request responsible for loading graph, simple smoke for now
+  cy.get('[data-test="namespace-dropdown"]').should('be.visible');
+  // not able to find correct request responsible for loading graph, simple smoke for now
 });
 
 Then('user sees Istio Config page elements from Kiali', () => {
-    cy.wait('@istioConfigRequest').then(() => {
-        cy.get('[data-test-id="filter-dropdown-toggle"]').should('be.visible')
-        cy.get('[data-test-id="dropdown-button"]').should('be.visible')
-        cy.get('[data-test-id="item-filter"]').should('be.visible')
-    })
+  cy.wait('@istioConfigRequest').then(() => {
+    cy.get('[data-test-id="filter-dropdown-toggle"]').should('be.visible');
+    cy.get('[data-test-id="dropdown-button"]').should('be.visible');
+    cy.get('[data-test-id="item-filter"]').should('be.visible');
+  });
 });

--- a/plugin/cypress/e2e/workloads-deployments.ts
+++ b/plugin/cypress/e2e/workloads-deployments.ts
@@ -4,11 +4,11 @@ Before(() => {
   // This prevents cypress from stopping on errors unrelated to the tests.
   // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
   // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, runnable, promise) => {
+  cy.on('uncaught:exception', (err, _runnable, promise) => {
     // when the exception originated from an unhandled promise
     // rejection, the promise is provided as a third argument
     // you can turn off failing the test in this case
-    if (promise) {
+    if (promise || err.message.includes('MobX')) {
       return false;
     }
     // we still want to ensure there are no other unexpected
@@ -41,5 +41,5 @@ When('Kiali container is selected', () => {
 });
 
 Then('user sees {string} dropdown', (dropdownText: string) => {
-  cy.get('span.pf-c-dropdown__toggle-text').contains(dropdownText).should('be.visible');
+  cy.get('span[class$="c-dropdown__toggle-text"]').contains(dropdownText).should('be.visible');
 });

--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -1,4 +1,7 @@
 /// <reference types="cypress" />
+
+import { isLocalhost } from './utils';
+
 // ***********************************************
 // This example commands.ts shows you how to
 // create various custom commands and overwrite
@@ -18,17 +21,20 @@ declare global {
 }
 
 Cypress.Commands.add('login', (OC_CLUSTER_USER, OC_CLUSTER_PASS, OC_IDP) => {
-  const user = OC_CLUSTER_USER || Cypress.env('OC_CLUSTER_USER');
-  const password = OC_CLUSTER_PASS || Cypress.env('OC_CLUSTER_PASS');
-  const idp = OC_IDP || Cypress.env('OC_IDP');
+  // Openshift Console from localhost does not have login page
+  if (!isLocalhost()) {
+    const user = OC_CLUSTER_USER || Cypress.env('OC_CLUSTER_USER');
+    const password = OC_CLUSTER_PASS || Cypress.env('OC_CLUSTER_PASS');
+    const idp = OC_IDP || Cypress.env('OC_IDP');
 
-  cy.visit('/').then(() => {
-    cy.log('OC_IDP: ', typeof idp, JSON.stringify(idp));
-    if (idp != undefined) {
-      cy.get('.pf-c-button').contains(idp).click();
-    }
-    cy.get('#inputUsername').clear().type(user);
-    cy.get('#inputPassword').clear().type(password);
-    cy.get('button[type="submit"]').click();
-  });
+    cy.visit('/').then(() => {
+      cy.log('OC_IDP: ', typeof idp, JSON.stringify(idp));
+      if (idp != undefined) {
+        cy.get('.pf-c-button').contains(idp).click();
+      }
+      cy.get('#inputUsername').clear().type(user);
+      cy.get('#inputPassword').clear().type(password);
+      cy.get('button[type="submit"]').click();
+    });
+  }
 });

--- a/plugin/cypress/support/e2e.ts
+++ b/plugin/cypress/support/e2e.ts
@@ -14,7 +14,9 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
+
+import './utils';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/plugin/cypress/support/step_definitions/common.ts
+++ b/plugin/cypress/support/step_definitions/common.ts
@@ -1,8 +1,8 @@
-import { Given } from "@badeball/cypress-cucumber-preprocessor";
+import { Given } from '@badeball/cypress-cucumber-preprocessor';
 
 Given('user is logged as administrator in OCP Console', () => {
-    const user = Cypress.env('OC_CLUSTER_USER')
-    // the two lines below can be done better, we don't need to check UI, in future we can hit API to check if user is logged in
-    cy.visit('/')
-    cy.get('.co-username').should('contain', user)
+  const user = Cypress.env('OC_CLUSTER_USER');
+  // the two lines below can be done better, we don't need to check UI, in future we can hit API to check if user is logged in
+  cy.visit('/');
+  cy.get('.co-username').should('contain', user);
 });

--- a/plugin/cypress/support/utils.ts
+++ b/plugin/cypress/support/utils.ts
@@ -1,0 +1,7 @@
+export const isLocalhost = () => {
+  return Cypress.config().baseUrl?.startsWith('http://localhost');
+};
+
+export const getApiProxy = () => {
+  return isLocalhost() ? '' : '/api/proxy/plugin/ossmconsole/kiali';
+};


### PR DESCRIPTION
### Describe the change
This PR adapts Cypress tests to work in all supported OpenShift versions (from 4.12 to 4.15).

Since OpenShift 4.15 uses version 5 of Patternfly library, all CSS classes have changed from `pf-c` to `pf-v5-c`, so current selectors used in Cypress do not work. To avoid this issue I have used selector [class$=".."] to check only the last part of the CSS class.

Regarding MobX issue, I just ignore uncaught exceptions that contain any `Mobx` reference.

As a bonus I have adapted Cypress tests to be able to run in localhost due to slightly differences with 'standard' OpenShift:
- There is no login page
- API_PROXY value is different

### Issue Reference
Fixes #274 