### PR TITLE
Isolate different versions of MobX for OCP 4.15

### DIFF
--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -6,6 +6,10 @@ import { useHistory } from 'react-router';
 import { setHistory } from 'app/History';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
 

--- a/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
@@ -5,6 +5,10 @@ import { IstioConfigDetailsPage } from 'pages/IstioConfigDetails/IstioConfigDeta
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const configTypes = {
   DestinationRule: 'DestinationRules',

--- a/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
@@ -8,6 +8,10 @@ import { getPluginConfig, useInitKialiListeners } from '../../utils/KialiIntegra
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { kialiStyle } from 'styles/StyleUtils';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
 

--- a/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
@@ -5,6 +5,10 @@ import { ServiceDetailsPage } from 'pages/ServiceDetails/ServiceDetailsPage';
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const ServiceMeshTab: React.FC<void> = () => {
   useInitKialiListeners();

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -5,6 +5,10 @@ import { WorkloadDetailsPage } from 'pages/WorkloadDetails/WorkloadDetailsPage';
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const WorkloadMeshTab: React.FC<void> = () => {
   useInitKialiListeners();

--- a/plugin/src/openshift/pages/OverviewPage.tsx
+++ b/plugin/src/openshift/pages/OverviewPage.tsx
@@ -4,6 +4,10 @@ import { useInitKialiListeners } from '../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { useHistory } from 'react-router';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions (from OCP 4.15 and OSSMC 1.73)
+configure({ isolateGlobalState: true });
 
 const OverviewPageOSSMC: React.FC<void> = () => {
   useInitKialiListeners();

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -4823,9 +4823,9 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 dompurify@^2.2.6:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
-  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.7.tgz#277adeb40a2c84be2d42a8bcd45f582bfa4d0cfc"
+  integrity sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
### Describe the change
In OpenShift 4.15, UI consoles uses version 5.1.0 of  `@patternfly/react-topology` library, which uses version 6.10.0 of `mobx` library.

On the other hand, OSSMC uses version 4.91.27 of `@patternfly/react-topology`, which uses version 5.15.7 of `mobx`.

Since multiple `mobx` instances are being used with different versions, following console error appears in the `Graph` page:
```
Error: The following error originated from your application code, not from Cypress.

  > [mobx] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
```

To fix the issue I have set `configure({ isolateGlobalState: true })` to any OSSMC page where graph is shown.

### Steps to test the PR
Go to `Graph` page and check that no console error related to `MobX` appears in the logs.

### Issue reference
#274 