### PR TITLE
Issue and PR templates for OSSMC repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+### Describe the bug
+
+A clear and concise description of the bug (provide screenshots if applicable). Report bugs that only happen in OSSMC. If the bug is present in Kiali application too, please open an issue [here](https://github.com/kiali/kiali/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=)
+
+### Expected Behavior
+
+### What are the steps to reproduce this bug?
+
+1. …
+2. …
+3. …
+
+### Environment
+
+Remember that OSSMC must match Kiali version. Learn about how to determine Kiali version [here](https://kiali.io/docs/faq/general/#how-do-i-determine-what-version-i-am-running).
+
+- **OSSMC/Kiali version:**
+- **OpenShift version:**
+- **Istio version:**
+- **Other notable environmental factors:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+### What do you want to improve?
+
+### What is the current behavior?
+
+### What is the new behavior?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+### Describe the change
+
+Explanation of what this PR does
+
+### Steps to test the PR
+
+Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.
+
+### Automation testing
+
+If applicable, explain the case scencarios covered by **e2e** tests created for this PR.
+
+### Issue reference
+
+If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))


### PR DESCRIPTION
### Describe the change
Add issues and PR templates to openshift-servicemesh-plugin repository, similar what we have in main Kiali repository.

I have reduced the number of issue types to bugs and features. Since this repo has much less activity, I think there is no need to have more issue types like discussions or documentation.

### Issue reference
Closes #255 