### PR TITLE
Add IPv6 nginx configuration

### DIFF
--- a/plugin/manifest.yaml
+++ b/plugin/manifest.yaml
@@ -92,6 +92,7 @@ data:
 
       server {
         listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
 


### PR DESCRIPTION
### Describe the change

This PR allows to deploy OSSM Console plugin in IPv6 OpenShift clusters.

### Steps to test the PR

Deploy OSSMConsole in IPv6 OpenShift cluster

### Automation testing

Not applicable

### Issue reference

#281 
