### PR TITLE
[v1.73] Isolate different versions of MobX for OCP 4.15

### DIFF
--- a/plugin/src/openshift/components/KialiContainer.tsx
+++ b/plugin/src/openshift/components/KialiContainer.tsx
@@ -22,7 +22,13 @@ import 'ace-builds/src-noconflict/ext-searchbox';
 const ossmcStyle = kialiStyle({
   display: 'flex',
   flexDirection: 'column',
-  overflowY: 'auto'
+  overflowY: 'auto',
+  $nest: {
+    '& ul': {
+      paddingLeft: 0,
+      listStyle: 'none'
+    }
+  }
 });
 
 interface Props {

--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -6,6 +6,10 @@ import { useHistory } from 'react-router';
 import { setHistory } from 'app/History';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
 

--- a/plugin/src/openshift/pages/IstioConfigListPage.tsx
+++ b/plugin/src/openshift/pages/IstioConfigListPage.tsx
@@ -162,7 +162,7 @@ const newIstioResourceList = {
   sidecar: 'Sidecar'
 };
 
-const IstioConfigListPage = () => {
+const IstioConfigListPage: React.FC = () => {
   const { ns } = useParams<{ ns: string }>();
   const [loaded, setLoaded] = React.useState<boolean>(false);
   const [listItems, setListItems] = React.useState<any[]>([]);

--- a/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
@@ -5,6 +5,10 @@ import { IstioConfigDetailsPage } from 'pages/IstioConfigDetails/IstioConfigDeta
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const configTypes = {
   DestinationRule: 'DestinationRules',

--- a/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
@@ -8,6 +8,10 @@ import { getPluginConfig, useInitKialiListeners } from '../../utils/KialiIntegra
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { kialiStyle } from 'styles/StyleUtils';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const containerPadding = kialiStyle({ padding: '0 20px 0 20px' });
 

--- a/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
@@ -5,6 +5,10 @@ import { ServiceDetailsPage } from 'pages/ServiceDetails/ServiceDetailsPage';
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const ServiceMeshTab: React.FC<void> = () => {
   useInitKialiListeners();

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -5,6 +5,10 @@ import { WorkloadDetailsPage } from 'pages/WorkloadDetails/WorkloadDetailsPage';
 import { useInitKialiListeners } from '../../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const WorkloadMeshTab: React.FC<void> = () => {
   useInitKialiListeners();

--- a/plugin/src/openshift/pages/OverviewPage.tsx
+++ b/plugin/src/openshift/pages/OverviewPage.tsx
@@ -4,6 +4,10 @@ import { useInitKialiListeners } from '../utils/KialiIntegration';
 import { setHistory } from 'app/History';
 import { useHistory } from 'react-router';
 import { KialiContainer } from 'openshift/components/KialiContainer';
+import { configure } from 'mobx';
+
+// Configure MobX to isolate different versions in OCP 4.15
+configure({ isolateGlobalState: true });
 
 const OverviewPageOSSMC: React.FC<void> = () => {
   useInitKialiListeners();


### PR DESCRIPTION
### Describe the change
In OpenShift 4.15, the UI console uses the version 5.1.0 of  `@patternfly/react-topology` library, which uses the version 6.10.0 of the `mobx` library.

On the other hand, OSSMC uses the version 4.91.27 of the `@patternfly/react-topology`, which uses the version 5.15.7 of `mobx`.

Since multiple `mobx` instances are being used with different versions, the following console error appears in the `Graph` page:
```
Error: The following error originated from your application code, not from Cypress.

  > [mobx] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
```

To fix the issue I have set `configure({ isolateGlobalState: true })` to any OSSMC page where the graph is shown.

I have also fixed a small style issue in the context menu:

Before:

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/40991acd-2e86-47e1-a175-3c21b808495c)

Now:

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/72465183-6c47-4bf7-9443-edf8718eaca5)


### Steps to test the PR
Go to `Graph` page and check that no console error related to `MobX` appears in the logs.

### Issue reference
#274 
