### PR TITLE
Initialize the load settings of the Istio config list page when switching namespaces

### DIFF
--- a/plugin/src/openshift/pages/IstioConfigListPage.tsx
+++ b/plugin/src/openshift/pages/IstioConfigListPage.tsx
@@ -165,8 +165,8 @@ const newIstioResourceList = {
 const IstioConfigListPage = () => {
   const { ns } = useParams<{ ns: string }>();
   const [loaded, setLoaded] = React.useState<boolean>(false);
-  const [listItems, setListItems] = React.useState<any[]>([]);
-  const [loadError, setLoadError] = React.useState<OSSMCError>();
+  const [listItems, setListItems] = React.useState<IstioConfigObject[]>([]);
+  const [loadError, setLoadError] = React.useState<OSSMCError | null>(null);
   const history = useHistory();
 
   const promises = React.useMemo(() => new PromisesRegistry(), []);
@@ -221,6 +221,10 @@ const IstioConfigListPage = () => {
   };
 
   React.useEffect(() => {
+    // initialize page
+    setLoaded(false);
+    setLoadError(null);
+
     fetchIstioConfigs()
       .then(istioConfigs => {
         const istioConfigObjects = istioConfigs.map(istioConfig => {
@@ -232,11 +236,12 @@ const IstioConfigListPage = () => {
         });
 
         setListItems(istioConfigObjects);
-        setLoaded(true);
       })
       .catch(error => {
         setLoadError({ title: error.response.statusText, message: error.response.data.error });
-        return [];
+      })
+      .finally(() => {
+        setLoaded(true);
       });
   }, [ns, fetchIstioConfigs]);
 


### PR DESCRIPTION
### Describe the change

Initialize the load settings of the Istio config list page when switching namespaces.

### Steps to test the PR

1. Change Kiali server config to allow only specific namespace to be accessible (avoid using the `**` value).
2. Navigate to Service Mesh -> Istio Config List.
3. Switch to forbidden namespace and verify that the `Forbidden` message appears.
4. Switch to accessible namespace and verify that the Istio Config items list is displayed.

### Automation testing

Automation testing for the Istio config list page to be implemented (https://github.com/kiali/openshift-servicemesh-plugin/issues/289)

### Issue reference

Fixes #288 