### PR TITLE
Download Kiali hack scripts from non-release branches

### DIFF
--- a/hack/download-hack-scripts.sh
+++ b/hack/download-hack-scripts.sh
@@ -27,9 +27,13 @@ rm -rf ${ABS_DEST_DIR}/{*,.[!.]*}
 # Get current OSSMC git branch to clone corresponding branch of Kiali (both applications should have the same version)
 KIALI_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ "${KIALI_BRANCH}" == "main" ]; then
-    KIALI_BRANCH="v1.73"
-fi
+case "${KIALI_BRANCH}" in
+    v1.*)
+        echo "OSSMC release branch ${KIALI_BRANCH}";;
+    *)
+        echo "This branch is not an OSSMC release branch (v1.*)"
+        KIALI_BRANCH="v1.73";;
+esac
 
 # Clone kiali repo into kiali folder (no-checkout option to avoid download whole repository)
 echo "Downloading hack scripts from Kiali branch ${KIALI_BRANCH}"


### PR DESCRIPTION
### Describe the change

Currently the Kiali hack scripts are downloaded to install bookinfo demo application. The installation script retrieves the OSSMC branch version and try to download the hack scripts from the same branch in Kiali. This works well for `main` or release branches, but not for local branches where there is no Kiali counterpart. 

In those cases I will set as default value the Kiali branch `v1.73` since OSSMC works currently with that Kiali server.
After the migration to PF5, default value must be set to `master` branch of Kiali.

### Steps to test the PR

Execute the script `hack/download-hack-scripts.sh` and check that Kiali hack scripts are being downloading from `v1.73 branch` (gh review is performed in a non-release branch)

### Automation testing

N/A

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/296
