### PR TITLE
[v1.73] Avoid multiple redirection when clicking on reference links

### DIFF
--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -74,13 +74,11 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
   private promises = new PromisesRegistry();
 
   state = {
-    configLoaded: false
+    loaded: false
   };
 
   componentDidMount(): void {
-    this.getKialiConfig();
-    this.getKialiSecurityInfo();
-    this.setDocLayout();
+    this.loadKiali();
   }
 
   componentWillUnmount(): void {
@@ -88,12 +86,21 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
   }
 
   render(): React.ReactNode {
-    return this.state.configLoaded ? (
+    return this.state.loaded ? (
       <>{this.props.children}</>
     ) : (
       <h1 className={centerVerticalHorizontalStyle}>Loading...</h1>
     );
   }
+
+  private loadKiali = async (): Promise<void> => {
+    await this.getKialiConfig();
+    await this.getKialiSecurityInfo();
+
+    this.applyUIDefaults();
+    this.setDocLayout();
+    this.setState({ loaded: true });
+  };
 
   private getKialiConfig = async (): Promise<void> => {
     try {
@@ -132,9 +139,6 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
         });
 
       await Promise.all([getNamespacesPromise, getServerConfigPromise, getStatusPromise, getJaegerInfoPromise]);
-
-      this.applyUIDefaults();
-      this.setState({ configLoaded: true });
     } catch (err) {
       console.error('Error loading kiali config', err);
     }
@@ -176,12 +180,14 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
       if (uiDefaults.metricsPerRefresh) {
         const validDurations = humanDurations(serverConfig, '', '');
         let metricsPerRefresh = 0;
+
         for (const [key, value] of Object.entries(validDurations)) {
           if (value === uiDefaults.metricsPerRefresh) {
             metricsPerRefresh = Number(key);
             break;
           }
         }
+
         if (metricsPerRefresh > 0) {
           this.props.setDuration(metricsPerRefresh);
           console.debug(
@@ -201,6 +207,7 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
             break;
           }
         }
+
         if (refreshInterval >= 0) {
           this.props.setRefreshInterval(refreshInterval);
           console.debug(`Setting UI Default: refreshInterval [${uiDefaults.refreshInterval}=${refreshInterval}ms]`);
@@ -223,6 +230,7 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
             console.debug(`Ignoring invalid UI Default: namespace [${name}]`);
           }
         }
+
         if (activeNamespaces.length > 0) {
           this.props.setActiveNamespaces(activeNamespaces);
           console.debug(`Setting UI Default: namespaces ${JSON.stringify(activeNamespaces.map(ns => ns.name))}`);
@@ -241,15 +249,19 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
       const httpRate = toHttpRate(uiDefaults.graph.traffic.http);
       const tcpRate = toTcpRate(uiDefaults.graph.traffic.tcp);
       const rates: TrafficRate[] = [];
+
       if (grpcRate) {
         rates.push(TrafficRate.GRPC_GROUP, grpcRate);
       }
+
       if (httpRate) {
         rates.push(TrafficRate.HTTP_GROUP, httpRate);
       }
+
       if (tcpRate) {
         rates.push(TrafficRate.TCP_GROUP, tcpRate);
       }
+
       this.props.setTrafficRates(rates);
     }
   };

--- a/plugin/src/openshift/utils/KialiIntegration.ts
+++ b/plugin/src/openshift/utils/KialiIntegration.ts
@@ -1,6 +1,7 @@
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { useHistory } from 'react-router-dom';
 import { refForKialiIstio } from './IstioResources';
+import { History } from 'history';
 
 export const properties = {
   // This API is hardcoded but:
@@ -25,6 +26,17 @@ export const getPluginConfig = async function (): Promise<PluginConfig> {
   });
 };
 
+// Navigates to the proper OpenShift Console page
+// If the Kiali event comes from an OSSMC page, add the new entry to the history.
+// Otherwise, last history entry is invalid and has to be replaced with the new one.
+const navigateToConsoleUrl = (history: History, url: string) => {
+  if (history.location.pathname.startsWith('/ossmconsole')) {
+    history.push(url);
+  } else {
+    history.replace(url);
+  }
+};
+
 // Global scope variable to hold the kiali listener
 let kialiListener: (Event: MessageEvent) => void;
 
@@ -44,17 +56,17 @@ export const useInitKialiListeners = () => {
 
       const webParamsIndex = kialiAction.indexOf('?');
 
+      let consoleUrl = '';
+
       // Transform Kiali domain messages into Plugin info that helps to navigate
       if (kialiAction.startsWith('/graph') || kialiAction.startsWith('/graphpf')) {
-        const servicemeshUrl = kialiAction
+        consoleUrl = kialiAction
           .replace('graph/namespaces', 'ossmconsole/graph')
           .replace('graphpf/namespaces', 'ossmconsole/graph')
           .replace('graph/node/namespaces', 'ossmconsole/graph/ns')
           .replace('graphpf/node/namespaces', 'ossmconsole/graph/ns');
-
-        history.push(servicemeshUrl);
       } else if (kialiAction.startsWith('/istio')) {
-        let istioConfigUrl = '/k8s';
+        consoleUrl = '/k8s';
 
         if (webParamsIndex > -1) {
           const nsParamIndex = kialiAction.indexOf('namespaces=', webParamsIndex);
@@ -67,12 +79,10 @@ export const useInitKialiListeners = () => {
           }
 
           const namespace = kialiAction.substring(nsParamIndex + 'namespaces='.length, endNsParamIndex);
-          istioConfigUrl += '/ns/' + namespace + '/istio';
+          consoleUrl += '/ns/' + namespace + '/istio';
         } else {
-          istioConfigUrl += '/all-namespaces/istio';
+          consoleUrl += '/all-namespaces/istio';
         }
-
-        history.push(istioConfigUrl);
       } else if (kialiAction.startsWith('/namespaces')) {
         const webParams = webParamsIndex > -1 ? kialiAction.substring(webParamsIndex) : '';
 
@@ -84,14 +94,12 @@ export const useInitKialiListeners = () => {
           webParamsIndex > -1 ? webParamsIndex : kialiAction.length
         );
 
-        let detailUrl = '';
-
         if (detail.startsWith('/applications')) {
           // OpenShift Console doesn't have an "application" concept
           // As the "app" concept is based on Pod "app" annotations, a start could be to show those pods
           // TBD a better link i.e. the "App" concept used for Developer preview
           const application = detail.substring('/applications/'.length);
-          detailUrl = '/k8s/ns/' + namespace + '/pods?labels=app%3D' + application;
+          consoleUrl = '/k8s/ns/' + namespace + '/pods?labels=app%3D' + application;
         }
 
         if (detail.startsWith('/workloads')) {
@@ -99,26 +107,26 @@ export const useInitKialiListeners = () => {
           // 99% of the cases there is a 1-to-1 mapping between Workload -> Deployment
           // YES, we have some old DeploymentConfig workloads there, but that can be addressed later
           const workload = detail.substring('/workloads'.length);
-          detailUrl = '/k8s/ns/' + namespace + '/deployments' + workload + '/ossmconsole' + webParams;
+          consoleUrl = '/k8s/ns/' + namespace + '/deployments' + workload + '/ossmconsole' + webParams;
         }
 
         if (detail.startsWith('/services')) {
           // OpenShift Console has a "services" list page
-          detailUrl = '/k8s/ns/' + namespace + detail + '/ossmconsole' + webParams;
+          consoleUrl = '/k8s/ns/' + namespace + detail + '/ossmconsole' + webParams;
         }
 
         if (detail.startsWith('/istio')) {
-          detailUrl = refForKialiIstio(detail);
+          consoleUrl = refForKialiIstio(detail);
 
-          if (detailUrl.length === 0) {
-            detailUrl = '/k8s/all-namespaces/istio';
+          if (consoleUrl.length === 0) {
+            consoleUrl = '/k8s/all-namespaces/istio';
           } else {
-            detailUrl = '/k8s/ns/' + namespace + detailUrl;
+            consoleUrl = '/k8s/ns/' + namespace + consoleUrl;
           }
         }
-
-        history.push(detailUrl);
       }
+
+      setTimeout(() => navigateToConsoleUrl(history, consoleUrl), 0);
     };
 
     window.addEventListener('message', kialiListener);

--- a/plugin/src/openshift/utils/KialiIntegration.ts
+++ b/plugin/src/openshift/utils/KialiIntegration.ts
@@ -126,7 +126,9 @@ export const useInitKialiListeners = () => {
         }
       }
 
-      setTimeout(() => navigateToConsoleUrl(history, consoleUrl), 0);
+      if (consoleUrl) {
+        setTimeout(() => navigateToConsoleUrl(history, consoleUrl), 0);
+      }
     };
 
     window.addEventListener('message', kialiListener);


### PR DESCRIPTION
### Describe the change

This PR avoids that OSSMC perform multiple redirections when clicking on reference links, such as a workload link related to a specific service.

**Note:** Found a possible issue because security information was loaded after the first initial render. Now I wait for all config and security requests before setting Kiali as loaded.

### Steps to test the PR

1. Go to the istio config list page
2. Click on any istio item
3. In the Service Mesh tab, click on any reference
4. Verify that the console navigates to the desired reference page
5. Click on the browser back button
6. Verify that the console navigates to the previous page

### Automation testing

To be included in https://github.com/kiali/openshift-servicemesh-plugin/issues/254

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/300
