### PR TITLE
[v1.73] Obtain the graph params from url pathname

### DIFF
--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { GraphPage, GraphURLPathProps } from 'pages/Graph/GraphPage';
+import { GraphPage } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
 import { getPluginConfig, useInitKialiListeners } from '../utils/KialiIntegration';
-import { useHistory, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { setHistory } from 'app/History';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiContainer } from 'openshift/components/KialiContainer';
@@ -28,10 +28,45 @@ const GraphPageOSSMC: React.FC<void> = () => {
       .catch(e => console.error(e));
   }, []);
 
-  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
+  const location = useLocation();
+  setHistory(location.pathname);
 
-  const history = useHistory();
-  setHistory(history.location.pathname);
+  // Obtain graph params from url pathname
+  const path = location.pathname.substring(19);
+  const items = path.split('/');
+
+  let namespace = '';
+  let aggregate = '';
+  let aggregateValue = '';
+  let app = '';
+  let version = '';
+  let service = '';
+  let workload = '';
+
+  if (items[0] === 'ns') {
+    namespace = items[1];
+
+    switch (items[2]) {
+      // URL pathname: ns/:namespace/aggregates/:aggregate/:aggregateValue
+      case 'aggregates':
+        aggregate = items[3];
+        aggregateValue = items[4];
+        break;
+      // URL pathname: ns/:namespace/applications/:app/versions/:version
+      case 'applications':
+        app = items[3];
+        version = items[5];
+        break;
+      // URL pathname: ns/:namespace/services/:service
+      case 'services':
+        service = items[3];
+        break;
+      // URL pathname: ns/:namespace/workloads/:workload
+      case 'workload':
+        workload = items[3];
+        break;
+    }
+  }
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { GraphPage } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
 import { getPluginConfig, useInitKialiListeners } from '../utils/KialiIntegration';
-import { useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { setHistory } from 'app/History';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiContainer } from 'openshift/components/KialiContainer';
@@ -28,11 +28,11 @@ const GraphPageOSSMC: React.FC<void> = () => {
       .catch(e => console.error(e));
   }, []);
 
-  const location = useLocation();
-  setHistory(location.pathname);
+  const history = useHistory();
+  setHistory(history.location.pathname);
 
   // Obtain graph params from url pathname
-  const path = location.pathname.substring(19);
+  const path = history.location.pathname.substring(19);
   const items = path.split('/');
 
   let namespace = '';


### PR DESCRIPTION
### Describe the change

Since `useParams` does not work for OCP 4.15, I have found a workaround to obtain the graph params from url pathname with `useLocation`. This PR allows the user to see the node graph details of a specific node.

### Steps to test the PR

1. Go to the Graph page
2. Click on the context menu of any node
3. Select the option 'Node Graph'
4. Verify that the console does not display the node graph details. Instead, the global traffic graph is refreshed.

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/ae7d30cd-4235-43e4-9acc-a31bd49e9dff)

### Automation testing

To be added in https://github.com/kiali/openshift-servicemesh-plugin/issues/254

### Issue reference

#304
