### PR TITLE
Adapt start-console.sh script to new file plugin-metadata.ts

### DIFF
--- a/plugin/start-console.sh
+++ b/plugin/start-console.sh
@@ -20,9 +20,9 @@ BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
 # BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
 BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
-BRIDGE_I18N_NAMESPACES="plugin__${npm_package_consolePlugin_name}"
+BRIDGE_I18N_NAMESPACES="plugin__${npm_package_name}"
 
-BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
+BRIDGE_PLUGINS="${npm_package_name}=http://host.docker.internal:9001"
 
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
@@ -34,13 +34,13 @@ echo "Console Platform: $CONSOLE_IMAGE_PLATFORM"
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9001"
+        BRIDGE_PLUGINS="${npm_package_name}=http://localhost:9001"
         podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm --network=host --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9001"
+        BRIDGE_PLUGINS="${npm_package_name}=http://host.containers.internal:9001"
         podman run --pull always --platform $CONSOLE_IMAGE_PLATFORM --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="${npm_package_name}=http://host.docker.internal:9001"
     docker run --pull always --platform $CONSOLE_IMAGE_PLATFORM--rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
### Describe the change

`start-console.sh` fails because the variable `npm_package_consolePlugin_name` does not longer exist (all plugin metadata has been extracted to the new file `plugin-metadata.ts`). This PR changes this variable to `npm_package_name` which contains the same value

### Steps to test the PR

Verify that `start-console.sh` script works

### Automation testing

N/A
