### PR TITLE
do not build ppc64le arch for now

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,4 +68,4 @@ jobs:
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
-        make build-push-plugin-multi-arch
+        make -e TARGET_ARCHS="amd64 arm64 s390x" build-push-plugin-multi-arch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,7 +225,7 @@ jobs:
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
-        make build-push-plugin-multi-arch
+        make -e TARGET_ARCHS="amd64 arm64 s390x" build-push-plugin-multi-arch
 
     - name: Create tag
       run: |


### PR DESCRIPTION
temporarily works around https://github.com/kiali/openshift-servicemesh-plugin/issues/312

We will want to revert this PR once we figure out how to get ppc64le built again.