### PR TITLE
[hack] do not consider it an error if nothing has changed

### DIFF
--- a/hack/copy-frontend-src-to-ossmc.sh
+++ b/hack/copy-frontend-src-to-ossmc.sh
@@ -165,17 +165,22 @@ ${COMMIT_MESSAGE}
 EOM
 
 git add ${ABS_DEST_DIR}
-git commit --quiet --signoff -m "${COMMIT_MESSAGE}"
+if git diff-index --quiet HEAD --; then
+  echo "There are no changes that need to be committed."
+else
+  echo "Committing changes now."
+  git commit --quiet --signoff -m "${COMMIT_MESSAGE}"
 
-# Completed!
-# Tell the user what needs to be done next.
-# This script does not automatically push the branch to the remote repo.
-# This script will only ever touch local files so as to avoid any possibility
-# of corrupting the remote repo.
+  # Completed!
+  # Tell the user what needs to be done next.
+  # This script does not automatically push the branch to the remote repo.
+  # This script will only ever touch local files so as to avoid any possibility
+  # of corrupting the remote repo.
 
-GIT_REMOTE="$(cd ${ABS_DEST_DIR} && for r in $(git remote 2>/dev/null); do if [ "$r" != "origin" ]; then echo ${r}; break; fi; done)"
-echo
-echo "=========="
-echo "Kiali frontend code has been copied to a new branch in the OSSMC git repo."
-echo "Create a PR based on that branch:"
-echo "cd ${ABS_DEST_DIR} && git push ${GIT_REMOTE:-<the git remote name>} ${DEST_BRANCH}"
+  GIT_REMOTE="$(cd ${ABS_DEST_DIR} && for r in $(git remote 2>/dev/null); do if [ "$r" != "origin" ]; then echo ${r}; break; fi; done)"
+  echo
+  echo "=========="
+  echo "Kiali frontend code has been copied to a new branch in the OSSMC git repo."
+  echo "Create a PR based on that branch:"
+  echo "cd ${ABS_DEST_DIR} && git push ${GIT_REMOTE:-<the git remote name>} ${DEST_BRANCH}"
+fi


### PR DESCRIPTION
If the main branch already has the updated Kiali server repo code, the hack script that is run by the release action will attempt to add/commit zero changed files and that results in "git commit" returning a non-zero exit code. This aborts the hack script and the release action assumes a failure occurred.

This is actually OK to happen - it just means we already updated the main branch with the latest code.

This PR checks to see if nothing needs to be committed, and if so, it just exits normally since this is an OK condition.