### PR TITLE
[github action] Copy Kiali source first before updating version numbers.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,10 +200,6 @@ jobs:
       with:
         ref: ${{ github.ref_name }}
 
-    - name: Set version to release
-      run: |
-        hack/update-version-string.sh "$RELEASE_VERSION"
-
     # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
     - name: Print disk space before
       run: df -h
@@ -220,6 +216,10 @@ jobs:
     - name: Copy Kiali source code
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$KIALI_SRC_CODE_VERSION"
+
+    - name: Set version to release
+      run: |
+        hack/update-version-string.sh "$RELEASE_VERSION"
 
     - name: Build and push images
       run: |


### PR DESCRIPTION
Rather than first updating the Makefile and related files with the new version, we need to copy the Kiali source code first. This is so we can avoid errors when nothing needs to be copied from the Kiali server repo.