### PR TITLE
Service mesh tab is loaded correctly after refresh

### DIFF
--- a/plugin/console-extensions.ts
+++ b/plugin/console-extensions.ts
@@ -215,17 +215,17 @@ const extensions: EncodedExtension[] = [
   consoleSection,
 
   // Console routes for each OSSMC page
-  ...consoleRoute('overview', 'Overview', Page.OVERVIEW, ['/ossmconsole/overview']),
+  ...consoleRoute('overview', 'Overview', Page.OVERVIEW, [`/${OSSM_CONSOLE}/overview`]),
   ...consoleRoute('graph', 'Traffic Graph', Page.GRAPH, [
-    '/ossmconsole/graph',
-    '/ossmconsole/graph/ns/:namespace/aggregates/:aggregate/:aggregateValue',
-    '/ossmconsole/graph/ns/:namespace/applications/:app/versions/:version',
-    '/ossmconsole/graph/ns/:namespace/applications/:app',
-    '/ossmconsole/graph/ns/:namespace/services/:service',
-    '/ossmconsole/graph/ns/:namespace/workloads/:workload'
+    `/${OSSM_CONSOLE}/graph`,
+    `/${OSSM_CONSOLE}/graph/ns/:namespace/aggregates/:aggregate/:aggregateValue`,
+    `/${OSSM_CONSOLE}/graph/ns/:namespace/applications/:app/versions/:version`,
+    `/${OSSM_CONSOLE}/graph/ns/:namespace/applications/:app`,
+    `/${OSSM_CONSOLE}/graph/ns/:namespace/services/:service`,
+    `/${OSSM_CONSOLE}/graph/ns/:namespace/workloads/:workload`
   ]),
   ...consoleRoute('istio', 'Istio Config', Page.ISTIO, ['/k8s/all-namespaces/istio', '/k8s/ns/:ns/istio']),
-  ...consoleRoute('mesh', 'Mesh', Page.MESH, ['/ossmconsole/mesh']),
+  ...consoleRoute('mesh', 'Mesh', Page.MESH, [`/${OSSM_CONSOLE}/mesh`]),
 
   // K8s horizontal navs - service mesh tab of k8s resources
   horizontalNav(K8sResource.Project, Tab.PROJECT),

--- a/plugin/src/openshift/locales/zh/translation.json
+++ b/plugin/src/openshift/locales/zh/translation.json
@@ -9,6 +9,10 @@
   "Name": "名称",
   "Namespace": "命名空间",
   "Overview": "概述",
+  "Service detail error": "Service detail error",
+  "Service is not defined correctly": "Service is not defined correctly",
   "Service Mesh": "服务网格",
-  "Traffic Graph": "图"
+  "Traffic Graph": "图",
+  "Workload detail error": "Workload detail error",
+  "Workload is not defined correctly": "Workload is not defined correctly"
 }

--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import { GraphPage, GraphURLPathProps } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
-import { getPluginConfig, useInitKialiListeners } from '../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { getPluginConfig, setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
 
@@ -16,16 +15,16 @@ const GraphPageOSSMC: React.FC<void> = () => {
     }
   });
 
+  const { pathname } = useLocation();
+  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
+
   React.useEffect(() => {
     getPluginConfig()
       .then(config => setPluginConfig(config))
       .catch(e => console.error(e));
   }, []);
 
-  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
-
-  const location = useLocation();
-  setHistory(location.pathname);
+  setRouterBasename(pathname);
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/pages/IstioConfigListPage.tsx
+++ b/plugin/src/openshift/pages/IstioConfigListPage.tsx
@@ -28,6 +28,7 @@ import { getIstioObject, getReconciliationCondition } from 'utils/IstioConfigUti
 import { ErrorPage, OSSMCError } from 'openshift/components/ErrorPage';
 import { ApiError } from 'types/Api';
 import { useKialiTranslation } from 'utils/I18nUtils';
+import { OSSM_CONSOLE } from 'openshift/utils/KialiIntegration';
 
 interface IstioConfigObject extends IstioObject {
   reconciledCondition?: StatusCondition;
@@ -87,7 +88,7 @@ const Row: React.FC<RowProps<IstioConfigObject>> = ({ obj, activeColumnIDs }) =>
 
   const istioObjectPath = `/k8s/ns/${obj.metadata.namespace}/${referenceFor(groupVersionKind)}/${
     obj.metadata.name
-  }/ossmconsole`;
+  }/${OSSM_CONSOLE}`;
 
   return (
     <>
@@ -169,14 +170,13 @@ const IstioTable: React.FC<IstioTableProps> = ({ columns, data, unfilteredData, 
 };
 
 const newIstioResourceList = {
-  authorization_policy: 'AuthorizationPolicy',
+  authorizationPolicy: 'AuthorizationPolicy',
   gateway: 'Gateway',
-  k8s_gateway: 'K8sGateway',
-  k8s_reference_grant: 'K8sReferenceGrant',
-  peer_authentication: 'PeerAuthentication',
-  request_authentication: 'RequestAuthentication',
-  service_entry: 'ServiceEntry',
-  sidecar: 'Sidecar'
+  k8sGateway: 'K8sGateway',
+  k8sReferenceGrant: 'K8sReferenceGrant',
+  peerAuthentication: 'PeerAuthentication',
+  requestAuthentication: 'RequestAuthentication',
+  serviceEntry: 'ServiceEntry'
 };
 
 const setKindApiVersion = (istioItems: IstioConfigItem[]): void => {

--- a/plugin/src/openshift/pages/MeshPage.tsx
+++ b/plugin/src/openshift/pages/MeshPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
-import { useInitKialiListeners } from '../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { MeshPage } from 'pages/Mesh/MeshPage';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
@@ -9,8 +8,9 @@ import { paddingContainer } from 'openshift/styles/GlobalStyle';
 const MeshPageOSSMC: React.FC<void> = () => {
   useInitKialiListeners();
 
-  const location = useLocation();
-  setHistory(location.pathname);
+  const { pathname } = useLocation();
+
+  setRouterBasename(pathname);
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
@@ -2,22 +2,20 @@ import * as React from 'react';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import { IstioConfigId } from 'types/IstioConfigDetails';
 import { IstioConfigDetailsPage } from 'pages/IstioConfigDetails/IstioConfigDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { ResourceURLPathProps, istioResources } from 'openshift/utils/IstioResources';
 import { ErrorPage } from 'openshift/components/ErrorPage';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 const IstioConfigMeshTab: React.FC<void> = () => {
-  const { t } = useKialiTranslation();
-
   useInitKialiListeners();
 
-  const location = useLocation();
-  setHistory(location.pathname);
-
+  const { t } = useKialiTranslation();
+  const { pathname } = useLocation();
   const { name, ns, plural } = useParams<ResourceURLPathProps>();
+
+  setRouterBasename(pathname);
 
   const errorPage = (
     <ErrorPage title={t('Istio detail error')} message={t('Istio object is not defined correctly')}></ErrorPage>

--- a/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
@@ -4,8 +4,7 @@ import { ActionKeys } from 'actions/ActionKeys';
 import { store } from 'store/ConfigStore';
 import { GraphPage } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
-import { getPluginConfig, useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { getPluginConfig, setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { ResourceURLPathProps } from 'openshift/utils/IstioResources';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
@@ -19,16 +18,16 @@ const ProjectMeshTab: React.FC<void> = () => {
     }
   });
 
+  const { pathname } = useLocation();
+  const { name: namespace } = useParams<ResourceURLPathProps>();
+
   React.useEffect(() => {
     getPluginConfig()
       .then(config => setPluginConfig(config))
       .catch(e => console.error(e));
   }, []);
 
-  const location = useLocation();
-  setHistory(location.pathname);
-
-  const { name: namespace } = useParams<ResourceURLPathProps>();
+  setRouterBasename(pathname);
 
   // Set namespace of the project as active namespace in redux store
   store.dispatch({ type: ActionKeys.SET_ACTIVE_NAMESPACES, payload: [{ name: namespace! }] });

--- a/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
@@ -2,32 +2,42 @@ import * as React from 'react';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import { ServiceId } from 'types/ServiceId';
 import { ServiceDetailsPage } from 'pages/ServiceDetails/ServiceDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { ResourceURLPathProps } from 'openshift/utils/IstioResources';
 import { grayContainer } from 'openshift/styles/GlobalStyle';
+import { useKialiTranslation } from 'utils/I18nUtils';
+import { ErrorPage } from 'openshift/components/ErrorPage';
 
 const ServiceMeshTab: React.FC<void> = () => {
   useInitKialiListeners();
 
-  const location = useLocation();
-  setHistory(location.pathname);
-
+  const { t } = useKialiTranslation();
+  const { pathname } = useLocation();
   const { ns, name } = useParams<ResourceURLPathProps>();
 
-  const serviceId: ServiceId = {
-    namespace: ns!,
-    service: name!
-  };
+  setRouterBasename(pathname);
 
-  return (
-    <KialiContainer>
-      <div className={grayContainer}>
-        <ServiceDetailsPage serviceId={serviceId}></ServiceDetailsPage>
-      </div>
-    </KialiContainer>
+  const errorPage = (
+    <ErrorPage title={t('Service detail error')} message={t('Service is not defined correctly')}></ErrorPage>
   );
+
+  if (ns && name) {
+    const serviceId: ServiceId = {
+      namespace: ns,
+      service: name
+    };
+
+    return (
+      <KialiContainer>
+        <div className={grayContainer}>
+          <ServiceDetailsPage serviceId={serviceId}></ServiceDetailsPage>
+        </div>
+      </KialiContainer>
+    );
+  } else {
+    return errorPage;
+  }
 };
 
 export default ServiceMeshTab;

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -2,54 +2,64 @@ import * as React from 'react';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import { WorkloadId } from 'types/Workload';
 import { WorkloadDetailsPage } from 'pages/WorkloadDetails/WorkloadDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { ResourceURLPathProps } from 'openshift/utils/IstioResources';
 import { grayContainer } from 'openshift/styles/GlobalStyle';
+import { ErrorPage } from 'openshift/components/ErrorPage';
+import { useKialiTranslation } from 'utils/I18nUtils';
 
 const WorkloadMeshTab: React.FC<void> = () => {
   useInitKialiListeners();
 
-  const location = useLocation();
-  setHistory(location.pathname);
-
+  const { t } = useKialiTranslation();
+  const { pathname } = useLocation();
   const { ns, name, plural } = useParams<ResourceURLPathProps>();
 
-  let workload = name!;
+  setRouterBasename(pathname);
 
-  if (plural === 'pods') {
-    let count = 0;
-    let index = 0;
+  const errorPage = (
+    <ErrorPage title={t('Workload detail error')} message={t('Workload is not defined correctly')}></ErrorPage>
+  );
 
-    // Get the parent workload (app-version) from pod identifier
-    for (let i = 0; i < workload.length; i++) {
-      if (workload[i] === '-') {
-        count++;
+  if (ns && name && plural) {
+    let workload = name;
 
-        if (count === 2) {
-          index = i;
+    if (plural === 'pods') {
+      let count = 0;
+      let index = 0;
+
+      // Get the parent workload (app-version) from pod identifier
+      for (let i = 0; i < workload.length; i++) {
+        if (workload[i] === '-') {
+          count++;
+
+          if (count === 2) {
+            index = i;
+          }
         }
+      }
+
+      if (index > 0) {
+        workload = workload.substring(0, index);
       }
     }
 
-    if (index > 0) {
-      workload = workload.substring(0, index);
-    }
+    const workloadId: WorkloadId = {
+      namespace: ns,
+      workload
+    };
+
+    return (
+      <KialiContainer>
+        <div className={grayContainer}>
+          <WorkloadDetailsPage workloadId={workloadId}></WorkloadDetailsPage>
+        </div>
+      </KialiContainer>
+    );
+  } else {
+    return errorPage;
   }
-
-  const workloadId: WorkloadId = {
-    namespace: ns!,
-    workload
-  };
-
-  return (
-    <KialiContainer>
-      <div className={grayContainer}>
-        <WorkloadDetailsPage workloadId={workloadId}></WorkloadDetailsPage>
-      </div>
-    </KialiContainer>
-  );
 };
 
 export default WorkloadMeshTab;

--- a/plugin/src/openshift/pages/OverviewPage.tsx
+++ b/plugin/src/openshift/pages/OverviewPage.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { OverviewPage } from 'pages/Overview/OverviewPage';
-import { useInitKialiListeners } from '../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 
 const OverviewPageOSSMC: React.FC<void> = () => {
   useInitKialiListeners();
 
-  const location = useLocation();
-  setHistory(location.pathname);
+  const { pathname } = useLocation();
+
+  setRouterBasename(pathname);
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/utils/KialiIntegration.ts
+++ b/plugin/src/openshift/utils/KialiIntegration.ts
@@ -3,11 +3,13 @@ import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom-v5-
 import { refForKialiIstio } from './IstioResources';
 import { setHistory } from 'app/History';
 
+export const OSSM_CONSOLE = 'ossmconsole';
+
 export const properties = {
   // This API is hardcoded but:
   // 'ossmconsole' is the name of the plugin, it can be considered "fixed" in the project
   // 'plugin-config.json' is a resource mounted from a ConfigMap, so, the UI app can read config from that file
-  pluginConfig: '/api/plugins/ossmconsole/plugin-config.json'
+  pluginConfig: `/api/plugins/${OSSM_CONSOLE}/plugin-config.json`
 };
 
 // This PluginConfig type should be mapped with the 'plugin-config.json' file
@@ -28,7 +30,7 @@ export const getPluginConfig = async (): Promise<PluginConfig> => {
 
 // Set the router basename where OSSMC page is loaded
 export const setRouterBasename = (pathname: string): void => {
-  const ossmConsoleIndex = pathname.indexOf('/ossmconsole');
+  const ossmConsoleIndex = pathname.indexOf(`/${OSSM_CONSOLE}`);
   const basename = pathname.substring(0, ossmConsoleIndex);
 
   setHistory(basename);
@@ -38,7 +40,7 @@ export const setRouterBasename = (pathname: string): void => {
 // If the Kiali event comes from an OSSMC page, add the new entry to the history.
 // Otherwise, last history entry is invalid and has to be replaced with the new one.
 const navigateToConsoleUrl = (pathname: string, navigate: NavigateFunction, url: string): void => {
-  if (pathname.startsWith('/ossmconsole')) {
+  if (pathname.startsWith(`/${OSSM_CONSOLE}`)) {
     navigate(url);
   } else {
     navigate(url, { replace: true });
@@ -70,10 +72,10 @@ export const useInitKialiListeners = (): void => {
       // Transform Kiali domain messages into Plugin info that helps to navigate
       if (kialiAction.startsWith('/graph') || kialiAction.startsWith('/graphpf')) {
         consoleUrl = kialiAction
-          .replace('graph/namespaces', 'ossmconsole/graph')
-          .replace('graphpf/namespaces', 'ossmconsole/graph')
-          .replace('graph/node/namespaces', 'ossmconsole/graph/ns')
-          .replace('graphpf/node/namespaces', 'ossmconsole/graph/ns');
+          .replace('graph/namespaces', `${OSSM_CONSOLE}/graph`)
+          .replace('graphpf/namespaces', `${OSSM_CONSOLE}/graph`)
+          .replace('graph/node/namespaces', `${OSSM_CONSOLE}/graph/ns`)
+          .replace('graphpf/node/namespaces', `${OSSM_CONSOLE}/graph/ns`);
       } else if (kialiAction.startsWith('/istio')) {
         consoleUrl = '/k8s';
 
@@ -116,12 +118,12 @@ export const useInitKialiListeners = (): void => {
           // 99% of the cases there is a 1-to-1 mapping between Workload -> Deployment
           // YES, we have some old DeploymentConfig workloads there, but that can be addressed later
           const workload = detail.substring('/workloads'.length);
-          consoleUrl = `/k8s/ns/${namespace}/deployments${workload}/ossmconsole${webParams}`;
+          consoleUrl = `/k8s/ns/${namespace}/deployments${workload}/${OSSM_CONSOLE}${webParams}`;
         }
 
         if (detail.startsWith('/services')) {
           // OpenShift Console has a "services" list page
-          consoleUrl = `/k8s/ns/${namespace}${detail}/ossmconsole${webParams}`;
+          consoleUrl = `/k8s/ns/${namespace}${detail}/${OSSM_CONSOLE}${webParams}`;
         }
 
         if (detail.startsWith('/istio')) {
@@ -130,7 +132,7 @@ export const useInitKialiListeners = (): void => {
           if (istioUrl.length === 0) {
             consoleUrl = '/k8s/all-namespaces/istio';
           } else {
-            consoleUrl = `/k8s/ns/${namespace}${istioUrl}/ossmconsole${webParams}`;
+            consoleUrl = `/k8s/ns/${namespace}${istioUrl}/${OSSM_CONSOLE}${webParams}`;
           }
         }
       }


### PR DESCRIPTION
### Describe the change

If the user goes to a Service details page, clicks on the `Service Mesh` tab, and refreshes the page, the Service Mesh details page gets stuck on the service mesh content info even though the active tab is the default `Details` tab. This PR fixes the issue by properly setting the router basename.

### Steps to test the PR

1. In OpenShift 4.15, go to any service details page
2. Click on the `Service Mesh` tab
3. Refresh the page
4. Verify that the service mesh tab content is shown and the active tab is the `Service Mesh` one.

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/68097b64-2f79-4aa5-a9e1-cf7f6c3f2712)

5. Verify that you can navigate correctly to the rest of the tabs of the Service Mesh.

![image](https://github.com/kiali/openshift-servicemesh-plugin/assets/122779323/7e1ff08a-fad9-4771-8fdd-22706d982933)

### Automation testing

To avoid conflicts due to test refactorization in #323, a test scenario covering this issue will be added in that PR or in a separate PR.

### Issue reference

Fixes #325 
