### PR TITLE
[v1.73] Service mesh tab is loaded correctly after refresh

### DIFF
--- a/plugin/src/kiali/services/Api.ts
+++ b/plugin/src/kiali/services/Api.ts
@@ -90,7 +90,7 @@ const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: 
   return axios.request<P>({
     method: method,
     url: apiProxy ? `${apiProxy}/${url}` : url,
-    data: apiProxy ? JSON.stringify(data) : data,
+    data: data,
     headers: getHeaders(),
     params: queryParams
   });
@@ -816,7 +816,7 @@ export const getIstioPermissions = (namespaces: string[], cluster?: string) => {
 };
 
 export const getMetricsStats = (queries: MetricsStatsQuery[]) => {
-  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, { queries: queries });
+  return newRequest<MetricsStatsResult>(HTTP_VERBS.POST, urls.metricsStats, {}, JSON.stringify({ queries }));
 };
 
 export const getClusters = () => {

--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { GraphPage } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
-import { getPluginConfig, useInitKialiListeners } from '../utils/KialiIntegration';
+import { getPluginConfig, setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegration';
 import { useHistory } from 'react-router-dom';
-import { setHistory } from 'app/History';
 import { kialiStyle } from 'styles/StyleUtils';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { configure } from 'mobx';
@@ -29,7 +28,7 @@ const GraphPageOSSMC: React.FC<void> = () => {
   }, []);
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   // Obtain graph params from url pathname
   const path = history.location.pathname.substring(19);

--- a/plugin/src/openshift/pages/IstioConfigListPage.tsx
+++ b/plugin/src/openshift/pages/IstioConfigListPage.tsx
@@ -155,7 +155,6 @@ const IstioTable = ({ columns, data, unfilteredData, loaded, loadError }: IstioT
 const newIstioResourceList = {
   authorization_policy: 'AuthorizationPolicy',
   gateway: 'Gateway',
-  k8s_gateway: 'K8sGateway',
   peer_authentication: 'PeerAuthentication',
   request_authentication: 'RequestAuthentication',
   service_entry: 'ServiceEntry',
@@ -228,7 +227,7 @@ const IstioConfigListPage: React.FC = () => {
 
   const onCreate = (reference: string) => {
     const groupVersionKind = istioResources.find(res => res.id === reference) as K8sGroupVersionKind;
-    const path = `/k8s/ns/${namespace ?? 'default'}/${referenceFor(groupVersionKind)}/~new`;
+    const path = `/k8s/ns/${namespace || 'default'}/${referenceFor(groupVersionKind)}/~new`;
     history.push(path);
   };
 

--- a/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { IstioConfigId } from 'types/IstioConfigDetails';
 import { IstioConfigDetailsPage } from 'pages/IstioConfigDetails/IstioConfigDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { configure } from 'mobx';
 
@@ -28,7 +27,7 @@ const IstioConfigMeshTab: React.FC<void> = () => {
   useInitKialiListeners();
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   const path = history.location.pathname.substring(8);
   const items = path.split('/');

--- a/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
@@ -4,8 +4,7 @@ import { ActionKeys } from 'actions/ActionKeys';
 import { store } from 'store/ConfigStore';
 import { GraphPage } from 'pages/Graph/GraphPage';
 import { GraphPagePF } from 'pages/GraphPF/GraphPagePF';
-import { getPluginConfig, useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { getPluginConfig, setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { kialiStyle } from 'styles/StyleUtils';
 import { configure } from 'mobx';
@@ -31,7 +30,7 @@ const ProjectMeshTab: React.FC<void> = () => {
   }, []);
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   const path = history.location.pathname.substring(8);
   const items = path.split('/');

--- a/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { ServiceId } from 'types/ServiceId';
 import { ServiceDetailsPage } from 'pages/ServiceDetails/ServiceDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { configure } from 'mobx';
 
@@ -14,7 +13,7 @@ const ServiceMeshTab: React.FC<void> = () => {
   useInitKialiListeners();
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   const path = history.location.pathname.substring(8);
   const items = path.split('/');

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { WorkloadId } from 'types/Workload';
 import { WorkloadDetailsPage } from 'pages/WorkloadDetails/WorkloadDetailsPage';
-import { useInitKialiListeners } from '../../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../../utils/KialiIntegration';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { configure } from 'mobx';
 
@@ -14,7 +13,7 @@ const WorkloadMeshTab: React.FC<void> = () => {
   useInitKialiListeners();
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   const path = history.location.pathname.substring(8);
   const items = path.split('/');

--- a/plugin/src/openshift/pages/OverviewPage.tsx
+++ b/plugin/src/openshift/pages/OverviewPage.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { OverviewPage } from 'pages/Overview/OverviewPage';
-import { useInitKialiListeners } from '../utils/KialiIntegration';
-import { setHistory } from 'app/History';
+import { setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegration';
 import { useHistory } from 'react-router-dom';
 import { KialiContainer } from 'openshift/components/KialiContainer';
 import { configure } from 'mobx';
@@ -13,7 +12,7 @@ const OverviewPageOSSMC: React.FC<void> = () => {
   useInitKialiListeners();
 
   const history = useHistory();
-  setHistory(history.location.pathname);
+  setRouterBasename(history.location.pathname);
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/utils/KialiIntegration.ts
+++ b/plugin/src/openshift/utils/KialiIntegration.ts
@@ -2,6 +2,7 @@ import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { useHistory } from 'react-router-dom';
 import { refForKialiIstio } from './IstioResources';
 import { History } from 'history';
+import { setHistory } from 'app/History';
 
 export const properties = {
   // This API is hardcoded but:
@@ -24,6 +25,14 @@ export const getPluginConfig = async function (): Promise<PluginConfig> {
       .then(config => resolve(config))
       .catch(error => reject(error));
   });
+};
+
+// Set the router basename where OSSMC page is loaded
+export const setRouterBasename = (pathname: string): void => {
+  const ossmConsoleIndex = pathname.indexOf('/ossmconsole');
+  const basename = pathname.substring(0, ossmConsoleIndex);
+
+  setHistory(basename);
 };
 
 // Navigates to the proper OpenShift Console page


### PR DESCRIPTION
Backport of PR #327 for branch v1.73

I have also fixed a small issue with `New Create` option in the Istio config list page with `all-namespaces` value.
