### PR TITLE
Upgrade to Node 20

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,7 +52,7 @@ jobs:
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM  registry.access.redhat.com/ubi8/nodejs-18 AS build
+FROM  registry.access.redhat.com/ubi8/nodejs-20 AS build
 
 USER root
 RUN command -v yarn || npm i -g yarn


### PR DESCRIPTION
### Describe the change

Upgrade to Node 20, including the Dockerfile and github actions (`actions/checkout` v4 runs on Node 20 while v3 runs on Node 16)

### Steps to test the PR

Check that OSSMC is built correctly

### Automation testing

N/A

### Issue reference

[#7503](https://github.com/kiali/kiali/issues/7503)
