### PR TITLE
Allow manual minor version release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,8 +77,8 @@ jobs:
         echo ${{ github.ref_name }}
         if [[ "${{ github.ref_name }}" == "main" ]];
         then
-          DO_RELEASE=$(python minor.py)
-          if [[ $DO_RELEASE == "1" ]]
+          SPRINT_RELEASE=$(python minor.py)
+          if [[ $SPRINT_RELEASE == "1" ]] || [[ "${{github.event_name}}" != "schedule" ]]
           then
             echo "release_type=minor" >> $GITHUB_ENV
           else


### PR DESCRIPTION
### Describe the change

Currently, manual releases of OSSMC minor versions (from the main branch) can only be done during release weeks (every 3 weeks). Although this is not a common scenario, OSSMC releases can be delayed due to blocking issues when copying Kiali source code. In such cases, manual releases could be triggered at any time to create a minor version (in case the fix takes more than a week).

For example, version v1.87 was not possible to be released because of a Kiali code issue (https://github.com/kiali/openshift-servicemesh-plugin/actions/runs/9849725845). The fix is merged but I cannot create a release because this week is not a "release week" (https://github.com/kiali/openshift-servicemesh-plugin/actions/runs/10044491281)
