### PR TITLE
Branch version as default Kiali source code in the release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,12 +153,12 @@ jobs:
 
     - name: Determine Kiali Source Code Version To Copy
       env:
-        RELEASE_VERSION: ${{ env.release_version }}
+        BRANCH_VERSION: ${{ env.branch_version }}
       id: determine_kiali_src_code_version
       run: |
         if [ -z "${{ github.event.inputs.kiali_source_code_version }}" ];
         then
-          KIALI_SRC_CODE_VERSION="$RELEASE_VERSION"
+          KIALI_SRC_CODE_VERSION="$BRANCH_VERSION"
         else
           KIALI_SRC_CODE_VERSION="${{ github.event.inputs.kiali_source_code_version }}"
         fi


### PR DESCRIPTION
### Describe the change

In the release script, Kiali code from the release tag version (e.g., v1.88.0) is copied into OSSMC. Although this option is correct, there are some scenarios where using the release tag version has drawbacks:

- If the code from the Kiali release tag breaks OSSMC and it is not possible to complete the release (the code from the tag cannot be updated).

- For patch versions, if Kiali and OSSMC versions are decoupled. For example, a new patch release of OSSMC does not necessarily need a new release of Kiali if the issue only affects OSSMC (and vice versa). In this case, OSSMC would try to copy a patch version tag (e.g., v1.88.1) that maybe does not exist in Kiali.

For this reason, I think the best approach is to copy the branch version (e.g., v1.88) instead of the release tag version (e.g., v1.88.0). With this option, we ensure that a new release of OSSMC contains the latest code from the Kiali branch and addresses both scenarios:

- The branch version can be updated, allowing the minor release of OSSMC (v1.88.0) to be launched.

- We do not have to check if Kiali and OSSMC patch versions are aligned when triggering a patch release of OSSMC.

Tracking the Kiali code copied into OSSMC is not an issue since the git commit reference is written in the README.

```
git ref:    v1.88
git commit: 139b6e879b2fc36f807fcd0d94d43b3fc7dc64e4
GitHub URL: https://github.com/kiali/kiali/tree/139b6e879b2fc36f807fcd0d94d43b3fc7dc64e4/frontend/src
```