### PR TITLE
[v1.73] Copy Kiali source code for release gh action for version 1.73

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
       branch_version: ${{ env.branch_version }}
       next_version: ${{ env.next_version }}
       plugin_quay_tag: ${{ env.plugin_quay_tag }}
+      kiali_src_code_version: ${{ env.kiali_src_code_version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
         type: string
         default: quay.io/kiali/ossmconsole
         required: true
+      kiali_source_code_version:
+        description: The version of the Kiali source code to build with OSSMC. This is either a branch or tag name. The default is the version of the OSSMC release being built. This means by default the versions of the Kiali source and OSSMC will be the same.
+        type: string
+        required: false
 
 jobs:
   initialize:
@@ -146,6 +150,20 @@ jobs:
 
         echo "plugin_quay_tag=$PLUGIN_QUAY_TAG" >> $GITHUB_ENV
 
+    - name: Determine Kiali Source Code Version To Copy
+      env:
+        BRANCH_VERSION: ${{ env.branch_version }}
+      id: determine_kiali_src_code_version
+      run: |
+        if [ -z "${{ github.event.inputs.kiali_source_code_version }}" ];
+        then
+          KIALI_SRC_CODE_VERSION="$BRANCH_VERSION"
+        else
+          KIALI_SRC_CODE_VERSION="${{ github.event.inputs.kiali_source_code_version }}"
+        fi
+
+        echo "kiali_src_code_version=$KIALI_SRC_CODE_VERSION" >> $GITHUB_ENV
+
     - name: Cleanup
       run: rm bump.py minor.py
 
@@ -172,11 +190,16 @@ jobs:
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       RELEASE_BRANCH: ${{ github.ref_name }}
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
+      KIALI_SRC_CODE_VERSION: ${{ needs.initialize.outputs.kiali_src_code_version }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         ref: ${{ github.ref_name }}
+
+    - name: Copy Kiali source code
+      run: |
+        hack/copy-frontend-src-to-ossmc.sh --source-ref "$KIALI_SRC_CODE_VERSION"
 
     - name: Set version to release
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,6 +198,20 @@ jobs:
       with:
         ref: ${{ github.ref_name }}
 
+    # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
+    - name: Print disk space before
+      run: df -h
+    - name: Free up space
+      run: rm -rf /opt/hostedtoolcache
+    - name: Print disk space after
+      run: df -h
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+
+        git config user.name 'kiali-bot'
+
     - name: Copy Kiali source code
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$KIALI_SRC_CODE_VERSION"
@@ -211,25 +225,11 @@ jobs:
         jq -r ".version |= \"${RELEASE_VERSION:1}\" | .consolePlugin.version |= \"${RELEASE_VERSION:1}\"" plugin/package.json > plugin/package.json.tmp
         mv plugin/package.json.tmp plugin/package.json
 
-    # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
-    - name: Print disk space before
-      run: df -h
-    - name: Free up space
-      run: rm -rf /opt/hostedtoolcache
-    - name: Print disk space after
-      run: df -h
-
     - name: Build and push images
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
         make build-push-plugin-multi-arch
-
-    - name: Configure git
-      run: |
-        git config user.email 'kiali-dev@googlegroups.com'
-
-        git config user.name 'kiali-bot'
 
     - name: Create tag
       run: |

--- a/hack/copy-frontend-src-to-ossmc.sh
+++ b/hack/copy-frontend-src-to-ossmc.sh
@@ -32,7 +32,6 @@ SOURCE_REPO_URL="${DEFAULT_SOURCE_REPO_URL}"
 # The git ref (branch or tag name) to checkout when cloning the source repo
 DEFAULT_SOURCE_REF="master"
 SOURCE_REF="${DEFAULT_SOURCE_REF}"
-PULL_REQUEST=""
 
 # This is to be the top-level directory of the local OSSM git repo.
 # This is where DEST_DIR should be located.
@@ -43,7 +42,6 @@ while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
     -dr|--dest-repo)     DEST_REPO="$2"         ;shift;shift ;;
-    -pr|--pull-request)  PULL_REQUEST="$2"      ;shift;shift ;;
     -sr|--source-ref)    SOURCE_REF="$2"        ;shift;shift ;;
     -su|--source-url)    SOURCE_REPO_URL="$2"   ;shift;shift ;;
     -h|--help)
@@ -57,13 +55,6 @@ Valid options:
       The Kiali "${SOURCE_DIR}" content will be copied to this destination
       repo's "${DEST_DIR}" directory.
       Default: ${DEFAULT_DEST_REPO}
-
-  -pr|--pull-request <pull request number>
-      A git reference (pull request number) found in the remote source repo. This is the
-      Kiali pull request that will be checked out when cloning the remote source repo.
-      This option takes precedence over the --source-ref option
-      See also: --source-ref
-      Default: ""
 
   -sr|--source-ref <branch or tag name>
       A git reference (branch or tag name) found in the remote source repo. This is the
@@ -117,19 +108,7 @@ if [ ! -d "${ABS_SOURCE_DIR}" ]; then
   exit 1
 fi
 
-cd ${ABS_SOURCE_DIR}
-
-if [ -n "${PULL_REQUEST}" ]; then
-  echo "Applying changes from PR ${PULL_REQUEST} (https://github.com/kiali/kiali/pull/${PULL_REQUEST})"
-  git fetch origin pull/${PULL_REQUEST}/head:pr-${PULL_REQUEST}
-  git checkout pr-${PULL_REQUEST}
-
-  GIT_REF="PR ${PULL_REQUEST}"
-else
-  GIT_REF="${SOURCE_REF}"
-fi
-
-COMMIT_HASH="$(git rev-parse HEAD)"
+COMMIT_HASH="$(cd ${ABS_SOURCE_DIR} && git rev-parse HEAD)"
 GITHUB_COMMIT_URL="https://github.com/kiali/kiali/tree/${COMMIT_HASH}/${SOURCE_DIR}"
 
 if ! curl --silent --show-error --fail "${GITHUB_COMMIT_URL}" > /dev/null; then
@@ -146,7 +125,7 @@ DEST_BRANCH="kiali-frontend-update-${DATETIME_NOW}"
 COMMIT_MESSAGE=$(cat <<EOM
 Copy of Kiali frontend source code
 Kiali frontend source originated from:
-* git ref:    ${GIT_REF}
+* git ref:    ${SOURCE_REF}
 * git commit: ${COMMIT_HASH}
 * GitHub URL: ${GITHUB_COMMIT_URL}
 EOM


### PR DESCRIPTION
### Describe the change

Currently, there are fixes in Kiali related to OSSMC being backported to v1.73 branch (e.g., https://www.github.com/kiali/kiali/pull/7605), which are not copied when new OSSMC patch release is triggered. This PR updates release gh action to copy the Kiali source code of branch v1.73.

Tested in my fork.