### PR TITLE
Add tag-creator GitHub action to OSSMC

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
-    - name: Checkout Backend
+    - name: Checkout branch
       uses: actions/checkout@v4
       with:
         ref: ${{matrix.branch}}
@@ -70,7 +70,7 @@ jobs:
         print('.'.join(['v' + str(major), str(minor), str(patch)]))
         EOF
 
-    - name: Configure git backend
+    - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
 

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -91,6 +91,11 @@ jobs:
 
         hack/update-version-string.sh "$RELEASE_VERSION"
 
-        git add Makefile plugin/package.json plugin/plugin-metadata.ts
+        git add Makefile plugin/package.json
+
+        if [[ $BRANCH != "v1.73"]]; then
+          git add plugin/plugin-metadata.ts
+        fi
+
         git commit -m "Release $RELEASE_VERSION"
         git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -1,0 +1,96 @@
+name: Tag Creator
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to tag, (Separate branches by commas. Ex v1.73,v1.86)
+        required: true
+        default: v1.73
+        type: string
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-20.04
+    outputs:
+      branches: ${{ env.branches }}
+    steps:
+    - name: Prepare script to var
+      id: script_convert
+      run: |
+        cat <<-EOF > conversor.py
+        import sys, json
+
+        branch_arg = sys.argv[1]
+        branches = branch_arg.split(',')
+
+        print(json.dumps(branches))
+        EOF
+
+    - name: Set Branch
+      id: branches
+      env:
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+      run: |
+        BRANCHES=$(python conversor.py $TAG_BRANCHES)
+        echo "branches=$BRANCHES" >> $GITHUB_ENV
+
+  create_tag:
+    needs: [initialize]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        branch: ${{fromJson(needs.initialize.outputs.branches)}}
+    steps:
+    - name: Checkout Backend
+      uses: actions/checkout@v4
+      with:
+        ref: ${{matrix.branch}}
+
+    - name: Prepare scripts
+      run: |
+        cat <<-EOF > bump.py
+        import sys
+        release_type = sys.argv[1]
+        version = sys.argv[2]
+        parts = version.split('.')
+        major = int(parts[0][1:])
+        minor = int(parts[1])
+        patch = int(parts[2])
+        if release_type == 'major':
+            major = major + 1
+            minor = 0
+            patch = 0
+        elif release_type == 'minor':
+            minor = minor + 1
+            patch = 0
+        elif release_type == 'patch':
+            patch = patch + 1
+        print('.'.join(['v' + str(major), str(minor), str(patch)]))
+        EOF
+
+    - name: Configure git backend
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+
+        git config user.name 'kiali-bot'
+
+    - name: Create Tag in kiali/openshift-servicemesh-plugin
+      id: tag_ossmc
+      env:
+        BRANCH: ${{matrix.branch}}
+      run: |
+        RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+        # Remove any pre release identifier (ie: "-SNAPSHOT")
+        RELEASE_VERSION=${RAW_VERSION%-*}
+        RELEASE_VERSION=$(python bump.py patch $RELEASE_VERSION)
+
+        echo "release_version=$RELEASE_VERSION" >> $GITHUB_ENV
+
+        hack/update-version-string.sh "$RELEASE_VERSION"
+
+        git add Makefile plugin/package.json plugin/plugin-metadata.ts
+        git commit -m "Release $RELEASE_VERSION"
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -98,4 +98,4 @@ jobs:
         fi
 
         git commit -m "Release $RELEASE_VERSION"
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -93,7 +93,7 @@ jobs:
 
         git add Makefile plugin/package.json
 
-        if [[ $BRANCH != "v1.73"]]; then
+        if [[ $BRANCH != "v1.73" ]]; then
           git add plugin/plugin-metadata.ts
         fi
 


### PR DESCRIPTION
### Describe the change

Add the tag-creator GitHub Action, similar to the one in the Kiali repository (see [Kiali tag-creator workflow](https://github.com/kiali/kiali/blob/master/.github/workflows/tag-creator.yml)), but adapted for the OSSMC repository.

Tested in my fork (https://github.com/ferhoyos/openshift-servicemesh-plugin/actions/runs/10346676413)
