### PR TITLE
[v1.73] Ensure OSSMC v1.73 is installed in cypress tests

### DIFF
--- a/hack/manage-ossmc.sh
+++ b/hack/manage-ossmc.sh
@@ -16,10 +16,7 @@ metadata:
   namespace: openshift-operators
   name: ossmconsole
 spec:
-  kiali:
-    serviceName: ''
-    serviceNamespace: ''
-  version: default
+  version: v1.73
 EOM
 }
 


### PR DESCRIPTION
### Describe the change

Ensure OSSMC v1.73 is installed in cypress tests

### Steps to test the PR

Verify that CI tests pass