### PR TITLE
[v1.73] Replace default cypress env variables

### DIFF
--- a/plugin/cypress.config.ts
+++ b/plugin/cypress.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
   videosFolder: 'cypress/videos',
 
   env: {
-    OC_CLUSTER_USER: 'jenkins', // default value for jenkins
-    OC_IDP: 'my_htpasswd_provider', // default value for jenkins, can vary based on cluster setup
+    USERNAME: 'jenkins', // default value for jenkins
+    AUTH_PROVIDER: 'my_htpasswd_provider', // default value for jenkins, can vary based on cluster setup
     'cypress-react-selector': {
       root: '#root'
     },

--- a/plugin/cypress/README.md
+++ b/plugin/cypress/README.md
@@ -11,9 +11,9 @@ Before you start using Cypress suite, you might need export some environment var
 
 ```bash
 export CYPRESS_BASE_URL=<value>               # defaults to http://localhost:9000
-export CYPRESS_OC_CLUSTER_USER=<value>        # defaults to jenkins, opt. kubeadmin
-export CYPRESS_OC_CLUSTER_PASS=<value>        # no defaults
-export CYPRESS_OC_IDP=<value>                 # defaults to my_htpasswd_provider
+export CYPRESS_USERNAME=<value>               # defaults to jenkins, opt. kubeadmin
+export CYPRESS_PASSWD=<value>                 # no defaults
+export CYPRESS_AUTH_PROVIDER=<value>          # defaults to my_htpasswd_provider
 ```
 
 

--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -15,20 +15,20 @@ import { isLocalhost } from './utils';
 declare global {
   namespace Cypress {
     interface Chainable {
-      login(OC_CLUSTER_USER: string, OC_CLUSTER_PASS: string, OC_IDP: string): Chainable<void>;
+      login(USERNAME: string, PASSWD: string, AUTH_PROVIDER: string): Chainable<void>;
     }
   }
 }
 
-Cypress.Commands.add('login', (OC_CLUSTER_USER, OC_CLUSTER_PASS, OC_IDP) => {
+Cypress.Commands.add('login', (USERNAME, PASSWD, AUTH_PROVIDER) => {
   // Openshift Console from localhost does not have login page
   if (!isLocalhost()) {
-    const user = OC_CLUSTER_USER || Cypress.env('OC_CLUSTER_USER');
-    const password = OC_CLUSTER_PASS || Cypress.env('OC_CLUSTER_PASS');
-    const idp = OC_IDP || Cypress.env('OC_IDP');
+    const user = USERNAME || Cypress.env('USERNAME');
+    const password = PASSWD || Cypress.env('PASSWD');
+    const idp = AUTH_PROVIDER || Cypress.env('AUTH_PROVIDER');
 
     cy.visit('/').then(() => {
-      cy.log('OC_IDP: ', typeof idp, JSON.stringify(idp));
+      cy.log('AUTH_PROVIDER: ', typeof idp, JSON.stringify(idp));
       if (idp != undefined) {
         cy.get('.pf-c-button').contains(idp).click();
       }

--- a/plugin/cypress/support/step_definitions/common.ts
+++ b/plugin/cypress/support/step_definitions/common.ts
@@ -2,7 +2,7 @@ import { Given } from '@badeball/cypress-cucumber-preprocessor';
 import { isLocalhost } from '../utils';
 
 Given('user is logged as administrator in OCP Console', () => {
-  const user = Cypress.env('OC_CLUSTER_USER');
+  const user = Cypress.env('USERNAME');
   // the two lines below can be done better, we don't need to check UI, in future we can hit API to check if user is logged in
   cy.visit('/');
 


### PR DESCRIPTION
### Describe the change

Partial backport of #357 where we replace the default user, password and auth provider cypress environment variables.

### Steps to test the PR

Verify that the Cypress tests run successfully

### Issue reference

https://github.com/kiali/openshift-servicemesh-plugin/issues/356
