### PR TITLE
[v1.73] Update dompurify dependency

### DIFF
--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -4851,9 +4851,9 @@ domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 dompurify@^2.2.6:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
-  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.7.tgz#6e0d36b9177db5a99f18ade1f28579db5ab839d7"
+  integrity sha512-2q4bEI+coQM8f5ez7kt2xclg1XsecaV9ASJk/54vwlfRRNQfDqJz2pzQ8t0Ix/ToBpXlVjrRIx7pFC/o8itG2Q==
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
### Describe the change

Updates the `dompurify` dependency in OSSMC version 1.73. This dependency is not used in the current `main` branch, so there is no need to update it there.

### Steps to test the PR

Verify that OSSMC works as expected

### Automation testing

N/A

### Issue reference

https://issues.redhat.com/browse/OSSM-8246