### PR TITLE
Enable graph tests in OSSMC

### DIFF
--- a/plugin/cypress.config.ts
+++ b/plugin/cypress.config.ts
@@ -13,10 +13,6 @@ export default defineConfig({
   requestTimeout: 15000,
   responseTimeout: 15000,
   fixturesFolder: 'cypress/fixtures',
-  chromeWebSecurity: true, // needs to disabled for cross origin requests
-  screenshotsFolder: 'cypress/screenshots',
-  videosFolder: 'cypress/videos',
-
   env: {
     'cypress-react-selector': {
       root: '#root'

--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -165,10 +165,10 @@ Cypress.Commands.overwrite('visit', (originalFn, visitUrl) => {
       visitUrl.url = `/k8s/ns/${namespace}${istioUrl}/ossmconsole${webParams}`;
     }
   } else {
-    if (targetPage === 'graph') {
+    if (targetPage === 'graphpf') {
       visitUrl.url = visitUrl.url
-        .replace('/console/graph/namespaces', '/ossmconsole/graph')
-        .replace('/console/graph/node/namespaces', '/ossmconsole/graph/ns');
+        .replace('/console/graphpf/namespaces', '/ossmconsole/graph')
+        .replace('/console/graphpf/node/namespaces', '/ossmconsole/graph/ns');
     } else if (targetPage === 'istio') {
       visitUrl.url = '/k8s/all-namespaces/istio';
     } else {

--- a/plugin/src/openshift/components/KialiContainer.tsx
+++ b/plugin/src/openshift/components/KialiContainer.tsx
@@ -8,6 +8,10 @@ import { globalStyle as ossmcStyle } from '../styles/GlobalStyle';
 import kialiCSSVariables from 'styles/variables.module.scss';
 import ossmcCSSVariables from '../styles/variables.module.scss';
 
+// Load the pf-icons
+import '@patternfly/patternfly/patternfly-base.css';
+
+// Load the tooltip style
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/dist/themes/light-border.css';
 

--- a/plugin/src/openshift/pages/GraphPage.tsx
+++ b/plugin/src/openshift/pages/GraphPage.tsx
@@ -7,16 +7,14 @@ import { KialiContainer } from 'openshift/components/KialiContainer';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
 
 const GraphPageOSSMC: React.FC<void> = () => {
-  useInitKialiListeners();
+  const { pathname } = useLocation();
+  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
 
   const [pluginConfig, setPluginConfig] = React.useState({
     graph: {
       impl: 'pf'
     }
   });
-
-  const { pathname } = useLocation();
-  const { aggregate, aggregateValue, app, namespace, service, version, workload } = useParams<GraphURLPathProps>();
 
   React.useEffect(() => {
     getPluginConfig()
@@ -25,6 +23,8 @@ const GraphPageOSSMC: React.FC<void> = () => {
   }, []);
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/pages/MeshPage.tsx
+++ b/plugin/src/openshift/pages/MeshPage.tsx
@@ -6,11 +6,11 @@ import { MeshPage } from 'pages/Mesh/MeshPage';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
 
 const MeshPageOSSMC: React.FC<void> = () => {
-  useInitKialiListeners();
-
   const { pathname } = useLocation();
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/IstioMesh.tsx
@@ -9,13 +9,13 @@ import { ErrorPage } from 'openshift/components/ErrorPage';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 const IstioConfigMeshTab: React.FC<void> = () => {
-  useInitKialiListeners();
-
   const { t } = useKialiTranslation();
   const { pathname } = useLocation();
   const { name, ns, plural } = useParams<ResourceURLPathProps>();
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   const errorPage = (
     <ErrorPage title={t('Istio detail error')} message={t('Istio object is not defined correctly')}></ErrorPage>

--- a/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ProjectMesh.tsx
@@ -10,16 +10,14 @@ import { ResourceURLPathProps } from 'openshift/utils/IstioResources';
 import { paddingContainer } from 'openshift/styles/GlobalStyle';
 
 const ProjectMeshTab: React.FC<void> = () => {
-  useInitKialiListeners();
+  const { pathname } = useLocation();
+  const { name: namespace } = useParams<ResourceURLPathProps>();
 
   const [pluginConfig, setPluginConfig] = React.useState({
     graph: {
       impl: 'pf'
     }
   });
-
-  const { pathname } = useLocation();
-  const { name: namespace } = useParams<ResourceURLPathProps>();
 
   React.useEffect(() => {
     getPluginConfig()
@@ -28,6 +26,8 @@ const ProjectMeshTab: React.FC<void> = () => {
   }, []);
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   // Set namespace of the project as active namespace in redux store
   store.dispatch({ type: ActionKeys.SET_ACTIVE_NAMESPACES, payload: [{ name: namespace! }] });

--- a/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/ServiceMesh.tsx
@@ -10,13 +10,13 @@ import { useKialiTranslation } from 'utils/I18nUtils';
 import { ErrorPage } from 'openshift/components/ErrorPage';
 
 const ServiceMeshTab: React.FC<void> = () => {
-  useInitKialiListeners();
-
   const { t } = useKialiTranslation();
   const { pathname } = useLocation();
   const { ns, name } = useParams<ResourceURLPathProps>();
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   const errorPage = (
     <ErrorPage title={t('Service detail error')} message={t('Service is not defined correctly')}></ErrorPage>

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -10,13 +10,13 @@ import { ErrorPage } from 'openshift/components/ErrorPage';
 import { useKialiTranslation } from 'utils/I18nUtils';
 
 const WorkloadMeshTab: React.FC<void> = () => {
-  useInitKialiListeners();
-
   const { t } = useKialiTranslation();
   const { pathname } = useLocation();
   const { ns, name, plural } = useParams<ResourceURLPathProps>();
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   const errorPage = (
     <ErrorPage title={t('Workload detail error')} message={t('Workload is not defined correctly')}></ErrorPage>

--- a/plugin/src/openshift/pages/OverviewPage.tsx
+++ b/plugin/src/openshift/pages/OverviewPage.tsx
@@ -5,11 +5,11 @@ import { setRouterBasename, useInitKialiListeners } from '../utils/KialiIntegrat
 import { KialiContainer } from 'openshift/components/KialiContainer';
 
 const OverviewPageOSSMC: React.FC<void> = () => {
-  useInitKialiListeners();
-
   const { pathname } = useLocation();
 
   setRouterBasename(pathname);
+
+  useInitKialiListeners();
 
   return (
     <KialiContainer>

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
-import { NavigateFunction, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { refForKialiIstio } from './IstioResources';
 import { setRouter } from 'app/History';
 
@@ -37,17 +37,6 @@ export const setRouterBasename = (pathname: string): void => {
   setRouter([{ element: <></> }], basename);
 };
 
-// Navigates to the proper OpenShift Console page
-// If the Kiali event comes from an OSSMC page, add the new entry to the history.
-// Otherwise, last history entry is invalid and has to be replaced with the new one.
-const navigateToConsoleUrl = (pathname: string, navigate: NavigateFunction, url: string): void => {
-  if (pathname.startsWith(`/${OSSM_CONSOLE}`)) {
-    navigate(url);
-  } else {
-    navigate(url, { replace: true });
-  }
-};
-
 // Global scope variable to hold the kiali listener
 let kialiListener: (Event: MessageEvent) => void;
 
@@ -55,7 +44,6 @@ let kialiListener: (Event: MessageEvent) => void;
 // When users "clicks" a link in Kiali, there is no navigation in the Kiali side; and event it's send to the parent
 // And the "plugin" is responsible to "navigate" to the proper page in the OpenShift Console with the proper context.
 export const useInitKialiListeners = (): void => {
-  const { pathname } = useLocation();
   const navigate = useNavigate();
 
   if (!kialiListener) {
@@ -139,7 +127,7 @@ export const useInitKialiListeners = (): void => {
       }
 
       if (consoleUrl) {
-        setTimeout(() => navigateToConsoleUrl(pathname, navigate, consoleUrl), 0);
+        setTimeout(() => navigate(consoleUrl), 0);
       }
     };
 


### PR DESCRIPTION
### Describe the change

Enable the patternfly cypress graph tests in OSSMC

**Bonus:**
- Change the order of initializing the Kiali listener due to a small navigation issue detected by one of the graph Cypress tests. However, the test is still failing, so I had to skip it in OSSMC (see https://github.com/kiali/kiali/pull/7846)
- Load the `pf-icons` CSS in OSSMC to display the graph icons.

Before: 

![image](https://github.com/user-attachments/assets/4e103f30-aae7-4fb4-a862-a0b4c119f532)

After:

![image](https://github.com/user-attachments/assets/05c33126-d8a7-447d-a4fd-729244da1546)


### Steps to test the PR

Verify that the CI tests for OSSMC are successful
