### PR TITLE
Validate login session in cypress tests

### DIFF
--- a/plugin/cypress/integration/openshift/common/hooks.ts
+++ b/plugin/cypress/integration/openshift/common/hooks.ts
@@ -57,6 +57,22 @@ const install_demoapp = (demoapp: string): void => {
   });
 };
 
+Before(() => {
+  // This prevents cypress from stopping on errors unrelated to the tests.
+  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
+  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
+  cy.on('uncaught:exception', (err, _runnable, promise) => {
+    // when the exception originated from an unhandled promise
+    // rejection, the promise is provided as a third argument
+    // you can turn off failing the test in this case
+    if (promise || err.message.includes('MobX')) {
+      return false;
+    }
+    // we still want to ensure there are no other unexpected
+    // errors, so we let them fail the test
+  });
+});
+
 Before({ tags: '@bookinfo-app' }, () => {
   install_demoapp('bookinfo');
 });

--- a/plugin/cypress/integration/openshift/common/istio_config.ts
+++ b/plugin/cypress/integration/openshift/common/istio_config.ts
@@ -1,23 +1,7 @@
-import { Before, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import { getColWithRowText } from './table';
 import { istioResources, referenceFor } from './istio_resources';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
-
-Before(() => {
-  // This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, _runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise || err.message.includes('MobX')) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
 
 Given('user is at the istio config list page', () => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing

--- a/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
+++ b/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
@@ -1,20 +1,4 @@
-import { Before, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-
-Before(() => {
-  // This prevents cypress from stopping on errors unrelated to the tests.
-  // There can be random failures due timeouts/loadtime/framework that throw browser errors.  This
-  // prevents a CI failure due something like a "slow".  There may be a better way to handle this.
-  cy.on('uncaught:exception', (err, _runnable, promise) => {
-    // when the exception originated from an unhandled promise
-    // rejection, the promise is provided as a third argument
-    // you can turn off failing the test in this case
-    if (promise || err.message.includes('MobX')) {
-      return false;
-    }
-    // we still want to ensure there are no other unexpected
-    // errors, so we let them fail the test
-  });
-});
+import { Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 When('user is at the dashboard page', () => {
   cy.visit({ url: `/` });

--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -79,7 +79,13 @@ Cypress.Commands.add('login', (clusterUser, clusterPassword, identityProvider) =
       });
     },
     {
-      cacheAcrossSpecs: true
+      cacheAcrossSpecs: true,
+      validate: () => {
+        cy.request({
+          url: `api/plugins/ossmconsole/plugin-manifest.json`,
+          method: 'GET'
+        });
+      }
     }
   );
 
@@ -180,7 +186,10 @@ Cypress.Commands.overwrite('visit', (originalFn, visitUrl) => {
 });
 
 Cypress.Commands.overwrite('request', (originalFn, request) => {
-  request.url = request.url?.replace('api/', 'api/proxy/plugin/ossmconsole/kiali/api/');
+  // don't overwrite specific requests to OSSMC plugin
+  if (!request.url?.includes('ossmconsole')) {
+    request.url = request.url?.replace('api/', 'api/proxy/plugin/ossmconsole/kiali/api/');
+  }
 
   if (request.method !== 'GET') {
     request.headers = { 'X-CSRFToken': csrfToken };


### PR DESCRIPTION
### Describe the change

This PR ensures that the login session is validated as active in every Cypress test scenario.

**Bonus:** 
- Only a single, generic `Before` statement is required for the entire Cypress test suite.

### Steps to test the PR

Verify that the CI tests pass

### Issue reference

Fixes https://github.com/kiali/openshift-servicemesh-plugin/issues/392
