### PR TITLE
Enable the release schedule in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  #schedule:
+  schedule:
   # Every Tuesday at 01:00 (UTC) which is the day after the server release is done. This action takes several hours to complete.
-  #- cron: "00 1 * * TUE"
+  - cron: "00 1 * * TUE"
   workflow_dispatch:
     inputs:
       release_type:
@@ -17,7 +17,7 @@ on:
       release_branch:
         description: Branch to release
         required: true
-        default: master
+        default: main
         type: string
       plugin_quay_repository:
         description: Plugin Quay repository


### PR DESCRIPTION
### Describe the change

Now that we have tested the new release GitHub Action and confirmed it works properly, it is time to enable the automated release schedule.

### Steps to test the PR

Verify that the github action is correct.

### Automation testing

N/A
