### PR TITLE
Copy kiali backports on tag creator GH action

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
 
-        git switch main
+        git switch $BRANCH
 
     - name: Create Tag in kiali/openshift-servicemesh-plugin
       id: tag_ossmc

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -82,8 +82,6 @@ jobs:
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
 
-        git switch $BRANCH
-
     - name: Create Tag in kiali/openshift-servicemesh-plugin
       id: tag_ossmc
       env:
@@ -106,4 +104,5 @@ jobs:
         fi
 
         git commit -m "Release $RELEASE_VERSION"
-        git push origin && git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       tag_branch:
-        description: Branch to tag, (Separate branches by commas. Ex v1.73,v1.86)
+        description: Branch to tag, (Separate branches by commas. Ex v2.4,v1.73)
         required: true
-        default: v1.73
+        default: v2.4
         type: string
 
 jobs:
@@ -81,6 +81,8 @@ jobs:
         BRANCH: ${{matrix.branch}}
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
+
+        git switch main
 
     - name: Create Tag in kiali/openshift-servicemesh-plugin
       id: tag_ossmc

--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -76,6 +76,12 @@ jobs:
 
         git config user.name 'kiali-bot'
 
+    - name: Copy Kiali source code
+      env:
+        BRANCH: ${{matrix.branch}}
+      run: |
+        hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
+
     - name: Create Tag in kiali/openshift-servicemesh-plugin
       id: tag_ossmc
       env:


### PR DESCRIPTION
### Describe the change

This PR copies Kiali backports from the Kiali repo into a specific branch before the creation of a release tag using the `Tag Creator` GH action. 

### Steps to test the PR

Tested on my fork: https://github.com/ferhoyos/openshift-servicemesh-plugin/actions/runs/13107785622

### Issue reference

Fixes #412 
