### PR TITLE
Fix istio cypress test for OCP 4.18

### DIFF
--- a/plugin/cypress/integration/openshift/common/istio_config.ts
+++ b/plugin/cypress/integration/openshift/common/istio_config.ts
@@ -51,7 +51,7 @@ Then('the user filters for {string}', (filterValue: string) => {
 });
 
 Then('the user can create a {string} Istio object in ossmc', (object: string) => {
-  cy.getBySel('item-create').find('button').click();
+  cy.getBySel('item-create').click();
 
   const istioResource = istioResources.find(item => item.id.toLowerCase() === object.toLowerCase());
 
@@ -66,7 +66,7 @@ Then('the user can create a {string} K8s Istio object in ossmc', (object: string
     expect(response.status).to.equal(200);
     const gatewayAPIEnabled = response.body.gatewayAPIEnabled;
 
-    cy.getBySel('item-create').find('button').click();
+    cy.getBySel('item-create').click();
 
     const istioResource = istioResources.find(item => item.id.toLowerCase() === object.toLowerCase());
 


### PR DESCRIPTION
### Describe the change

Fix the `istio_config.feature` cypress test for OCP 4.18.

### Steps to test the PR

Verify that cypress test pass with OCP 4.18

### Issue reference

Fixes #423 
