### PR TITLE
[OSSMC] View in tracing integration with the tracing UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,46 @@ yarn run start-console
 
 At this point, the OpenShift Console will start and be accessible at http://localhost:9000
 
+### Testing Locally Distributed Tracing integration
+
+For testing the distributed tracing integration locally, assign to distributedTracingPluginConfig in the getDistributedTracingPluginManifestPromise in the KialiController the following data: 
+
+```sh
+  distributedTracingPluginConfig = {
+    "name": "distributed-tracing-console-plugin",
+    "version": "0.0.1",
+    "displayName": "Distributed Tracing Plugin",
+    "description": "This plugin adds a distributed tracing UI to the Openshift console.",
+    "dependencies": {
+      "@console/pluginAPI": "*"
+    },
+    "extensions": [
+      {
+        "type": "console.page/route",
+        "properties": {
+          "exact": false,
+          "path": "/observe/traces",
+          "component": {
+            "$codeRef": "TracingUI"
+          }
+        }
+      },
+      {
+        "type": "console.navigation/href",
+        "properties": {
+          "id": "distributed-tracing",
+          "name": "Traces",
+          "href": "/observe/traces",
+          "perspective": "admin",
+          "section": "observe"
+        }
+      }
+    ]
+  }
+```
+
+That will help to validate if the logic and the URL are right, but in the localhost plugin it won't load the distributed tracing plugin page. 
+
 ## Operator
 
 The OpenShift Service Mesh Console will be installed by end users using the Kiali Operator.

--- a/plugin/plugin-config.json
+++ b/plugin/plugin-config.json
@@ -1,5 +1,10 @@
 {
   "graph": {
     "impl": "pf"
+  },
+  "observability": {
+    "instance": "sample",
+    "namespace": "tempo",
+    "tenant": "default"
   }
 }

--- a/plugin/src/kiali/actions/__tests__/JaegerActions.test.ts
+++ b/plugin/src/kiali/actions/__tests__/JaegerActions.test.ts
@@ -6,6 +6,7 @@ describe('JaegerActions', () => {
     const showAction = TracingActions.setInfo({
       enabled: true,
       integration: true,
+      internalURL: '',
       url: 'jaeger-query-istio-system.127.0.0.1.nip.io',
       namespaceSelector: true,
       provider: 'jaeger',

--- a/plugin/src/kiali/reducers/__tests__/TracingStateReducer.test.ts
+++ b/plugin/src/kiali/reducers/__tests__/TracingStateReducer.test.ts
@@ -5,6 +5,7 @@ const initialState: TracingState = {
   info: {
     enabled: false,
     integration: false,
+    internalURL: '',
     url: '',
     namespaceSelector: true,
     provider: 'jaeger',
@@ -28,6 +29,7 @@ describe('TracingState reducer', () => {
         initialState,
         TracingActions.setInfo({
           url: url,
+          internalURL: '',
           enabled: true,
           integration: true,
           namespaceSelector: true,

--- a/plugin/src/kiali/types/TracingInfo.ts
+++ b/plugin/src/kiali/types/TracingInfo.ts
@@ -7,6 +7,7 @@ import { Target } from './MetricsOptions';
 export interface TracingInfo {
   enabled: boolean;
   integration: boolean;
+  internalURL: string;
   namespaceSelector: boolean;
   provider: string;
   url: string;

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -82,11 +82,6 @@ type KialiControllerProps = KialiControllerReduxProps & {
 const defaultPluginConfig: PluginConfig = {
   graph: {
     impl: 'pf'
-  },
-  observability: {
-    instance: 'sample',
-    namespace: 'tempo',
-    tenant: 'default'
   }
 };
 
@@ -95,6 +90,9 @@ export {pluginConfig};
 
 let distributedTracingPluginConfig:OpenShiftPluginConfig;
 export {distributedTracingPluginConfig};
+
+let tracingInfo: TracingInfo;
+export {tracingInfo};
 
 class KialiControllerComponent extends React.Component<KialiControllerProps> {
   private promises = new PromisesRegistry();
@@ -168,40 +166,7 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
         .then(response => (distributedTracingPluginConfig = (response)))
         .catch(error => {
           console.debug(`Error fetching Distributed Tracing plugin configuration. (Probably is not installed) ${error}`)
-          // Enable this for testing locally
-          /*
-          distributedTracingPluginConfig = {
-            "name": "distributed-tracing-console-plugin",
-            "version": "0.0.1",
-            "displayName": "Distributed Tracing Plugin",
-            "description": "This plugin adds a distributed tracing UI to the Openshift console.",
-            "dependencies": {
-              "@console/pluginAPI": "*"
-            },
-            "extensions": [
-              {
-                "type": "console.page/route",
-                "properties": {
-                  "exact": false,
-                  "path": "/observe/traces",
-                  "component": {
-                    "$codeRef": "TracingUI"
-                  }
-                }
-              },
-              {
-                "type": "console.navigation/href",
-                "properties": {
-                  "id": "distributed-tracing",
-                  "name": "Traces",
-                  "href": "/observe/traces",
-                  "perspective": "admin",
-                  "section": "observe"
-                }
-              }
-            ]
-          }
-           */
+          // For testing the distributed tracing integration locally, assign distributedTracingPluginConfig = "plugin manifest json"
         });
       API.getStatus()
         .then(response => this.processServerStatus(response.data))

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -10,7 +10,11 @@ import { StatusKey, StatusState } from 'types/StatusState';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import * as API from 'services/Api';
 import * as AlertUtils from 'utils/AlertUtils';
-import {humanDurations, serverConfig, setServerConfig, setTracingInfo} from 'config/ServerConfig';
+import {
+  humanDurations,
+  serverConfig,
+  setServerConfig
+} from 'config/ServerConfig';
 import { config } from 'config';
 import { KialiDispatch } from 'types/Redux';
 import { MessageCenterActions } from 'actions/MessageCenterActions';
@@ -22,7 +26,12 @@ import { LoginActions } from 'actions/LoginActions';
 import { GraphToolbarActions } from 'actions/GraphToolbarActions';
 import { HelpDropdownActions } from 'actions/HelpDropdownActions';
 import { GlobalActions } from 'actions/GlobalActions';
-import {getDistributedTracingPluginManifest, getPluginConfig, PluginConfig} from 'openshift/utils/KialiIntegration';
+import {
+  getDistributedTracingPluginManifest,
+  getPluginConfig,
+  OpenShiftPluginConfig,
+  PluginConfig
+} from 'openshift/utils/KialiIntegration';
 import { MeshTlsActions } from 'actions/MeshTlsActions';
 import { TLSStatus } from 'types/TLSStatus';
 import { IstioCertsInfoActions } from 'actions/IstioCertsInfoActions';
@@ -83,6 +92,9 @@ const defaultPluginConfig: PluginConfig = {
 
 let pluginConfig: PluginConfig = defaultPluginConfig;
 export {pluginConfig};
+
+let distributedTracingPluginConfig:OpenShiftPluginConfig;
+export {distributedTracingPluginConfig};
 
 class KialiControllerComponent extends React.Component<KialiControllerProps> {
   private promises = new PromisesRegistry();
@@ -153,12 +165,12 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
 
       const getDistributedTracingPluginManifestPromise = this.promises
         .register('getDistributedTracingPluginManifestPromise', getDistributedTracingPluginManifest())
-        .then(response => (setTracingInfo(response)))
+        .then(response => (distributedTracingPluginConfig = (response)))
         .catch(error => {
           console.debug(`Error fetching Distributed Tracing plugin configuration. (Probably is not installed) ${error}`)
           // Enable this for testing locally
           /*
-          setTracingInfo({
+          distributedTracingPluginConfig = {
             "name": "distributed-tracing-console-plugin",
             "version": "0.0.1",
             "displayName": "Distributed Tracing Plugin",
@@ -188,7 +200,7 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
                 }
               }
             ]
-          })
+          }
            */
         });
       API.getStatus()

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -91,9 +91,6 @@ export {pluginConfig};
 let distributedTracingPluginConfig:OpenShiftPluginConfig;
 export {distributedTracingPluginConfig};
 
-let tracingInfo: TracingInfo;
-export {tracingInfo};
-
 class KialiControllerComponent extends React.Component<KialiControllerProps> {
   private promises = new PromisesRegistry();
 

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -144,17 +144,17 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
         });
 
       const getTracingInfoPromise = this.promises
-                .register('getTracingInfo', API.getTracingInfo())
-              .then(response => this.props.setTracingInfo(response.data))
-              .catch(error => {
-                  this.props.setTracingInfo(null);
-                  AlertUtils.addError(
-                      'Could not fetch Tracing info. Turning off Tracing integration.',
-                      error,
-                      'default',
-                      MessageType.INFO
-                    );
-                });
+        .register('getTracingInfo', API.getTracingInfo())
+        .then(response => this.props.setTracingInfo(response.data))
+        .catch(error => {
+          this.props.setTracingInfo(null);
+          AlertUtils.addError(
+            'Could not fetch Tracing info. Turning off Tracing integration.',
+            error,
+            'default',
+            MessageType.INFO
+          );
+        });
 
       const getPluginPromise = this.promises
         .register('getPluginPromise', getPluginConfig())

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -170,18 +170,17 @@ export const useInitKialiListeners = (): void => {
               consoleUrl = `/observe/traces?namespace=${namespace}&name=${instance}&tenant=${tenant}&q=%7B%7D&limit=20`
             }
             setTimeout(() => navigate(consoleUrl), 0);
-          }
-        else {
+        } else {
             const urlParams = new URLSearchParams(kialiAction.split('?')[1]);
             const url = urlParams.get('url');
             if (url) {
               window.location.href = url;
             }
         }
+      }
 
-        if (consoleUrl) {
-          setTimeout(() => navigate(consoleUrl), 0);
-        }
+      if (consoleUrl) {
+        setTimeout(() => navigate(consoleUrl), 0);
       }
     };
 

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -163,7 +163,7 @@ export const useInitKialiListeners = (): void => {
 
         if (distributedTracingPluginConfig && distributedTracingPluginConfig.extensions.length > 0 && pluginConfig) {
           const urlParams = new URLSearchParams(kialiAction.split('?')[1]);
-          let observabilityData: Observability|null;
+          let observabilityData: Observability|null = null;
           if (pluginConfig.observability) {
             observabilityData = {
                 instance: pluginConfig.observability.instance,

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -3,8 +3,8 @@ import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { refForKialiIstio } from './IstioResources';
 import { setRouter } from 'app/History';
-import {distributedTracingPluginConfig, OpenShiftPluginConfig} from "config/ServerConfig";
-import {pluginConfig} from "../components/KialiController";
+
+import {distributedTracingPluginConfig, pluginConfig} from "../components/KialiController";
 
 export const OSSM_CONSOLE = 'ossmconsole';
 
@@ -28,6 +28,20 @@ export type PluginConfig = {
     tenant: string;
   };
 };
+
+interface PluginExtension {
+  properties: Record<string, any>;
+  type: string;
+}
+
+export interface OpenShiftPluginConfig {
+  dependencies: Record<string, string>;
+  description: string;
+  displayName: string;
+  extensions: PluginExtension[];
+  name: string;
+  version: string;
+}
 
 // Get OSSMC plugin config from 'plugin-config.json' resource
 export const getPluginConfig = async (): Promise<PluginConfig> => {

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -201,7 +201,7 @@ export const useInitKialiListeners = (): void => {
 };
 
 function parseTempoUrl(url): Observability|null {
-  const regex = /https?:\/\/tempo-([a-zA-Z0-9-]+?)(?:-gateway)?\.([a-zA-Z0-9-]+)\..*\/api\/traces\/v1(?:\/([^\/]+))?/;
+  const regex = /https?:\/\/tempo-([a-zA-Z0-9-]+?)(?:-gateway)?\.([a-zA-Z0-9-]+)\..*\/api\/traces\/v1(?:\/([^/]+))?/;
   const match = url.match(regex);
 
   if (!match) return null;

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -208,7 +208,17 @@ export function parseTempoUrl(url: string): Observability|null {
   const regex = /https?:\/\/tempo-([a-zA-Z0-9-]+?)(?:-gateway)?\.([a-zA-Z0-9-]+)\..*\/api\/traces\/v1(?:\/([^/]+))?/;
   const match = url.match(regex);
 
-  if (!match) return null;
+  if (!match) {
+    // Try non tenants
+    const regexT = /https?:\/\/tempo-([a-zA-Z0-9-]+?)(?:-query-frontend)?\.([a-zA-Z0-9-]+)\..*(?:\/([^/]+))?/;
+    const matchT = url.match(regexT);
+
+    if (!matchT) return null
+    return {
+      instance: matchT[1],
+      namespace: matchT[2]
+    };
+  }
 
   return {
     instance: match[1],

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -21,7 +21,7 @@ export const properties = {
 type Observability = {
   instance: string;
   namespace: string;
-  tenant: string;
+  tenant?: string;
 }
 
 // This PluginConfig type should be mapped with the 'plugin-config.json' file
@@ -204,7 +204,7 @@ export const useInitKialiListeners = (): void => {
   }
 };
 
-function parseTempoUrl(url): Observability|null {
+export function parseTempoUrl(url: string): Observability|null {
   const regex = /https?:\/\/tempo-([a-zA-Z0-9-]+?)(?:-gateway)?\.([a-zA-Z0-9-]+)\..*\/api\/traces\/v1(?:\/([^/]+))?/;
   const match = url.match(regex);
 
@@ -213,6 +213,6 @@ function parseTempoUrl(url): Observability|null {
   return {
     instance: match[1],
     namespace: match[2],
-    tenant: match[3] || null
+    tenant: match[3]
   };
 }

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -162,27 +162,29 @@ export const useInitKialiListeners = (): void => {
       } else if (kialiAction.startsWith('/tracing')) {
 
         if (distributedTracingPluginConfig && distributedTracingPluginConfig.extensions.length > 0 && pluginConfig) {
-            const urlParams = new URLSearchParams(kialiAction.split('?')[1]);
-            let observabilityData: Observability|null;
-            if (pluginConfig.observability) {
-              observabilityData = {
+          const urlParams = new URLSearchParams(kialiAction.split('?')[1]);
+          let observabilityData: Observability|null;
+          if (pluginConfig.observability) {
+            observabilityData = {
                 instance: pluginConfig.observability.instance,
                 namespace: pluginConfig.observability.namespace,
                 tenant: pluginConfig.observability.tenant
-              };
-            } else {
-              const tracingInfo = store.getState().tracingState.info
+            };
+          } else {
+            const tracingInfo = store.getState().tracingState.info
+            if (tracingInfo) {
               observabilityData = parseTempoUrl(tracingInfo.internalURL)
             }
+          }
 
-           if (observabilityData) {
+          if (observabilityData) {
               const trace = urlParams.get('trace');
               if (trace && trace !== "undefined") {
                 consoleUrl = `/observe/traces/${trace}?namespace=${observabilityData.namespace}&name=${observabilityData.instance}&tenant=${observabilityData.tenant}`
               } else {
                 consoleUrl = `/observe/traces?namespace=${observabilityData.namespace}&name=${observabilityData.instance}&tenant=${observabilityData.tenant}&q=%7B%7D&limit=20`
               }
-            }
+          }
 
         } else {
             const urlParams = new URLSearchParams(kialiAction.split('?')[1]);

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -163,7 +163,8 @@ export const useInitKialiListeners = (): void => {
             const namespace = pluginConfig.observability.namespace;
             const instance = pluginConfig.observability.instance;
             const trace = urlParams.get('trace');
-            const tenant = pluginConfig.observability.tenant ? pluginConfig.observability.tenant : "default"
+            const tenant = pluginConfig.observability.tenant ?? "default";
+            
             if (trace && trace !== "undefined") {
               consoleUrl = `/observe/traces/${trace}?namespace=${namespace}&name=${instance}&tenant=${tenant}`
             } else {

--- a/plugin/src/openshift/utils/KialiIntegration.tsx
+++ b/plugin/src/openshift/utils/KialiIntegration.tsx
@@ -4,7 +4,8 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { refForKialiIstio } from './IstioResources';
 import { setRouter } from 'app/History';
 
-import {distributedTracingPluginConfig, pluginConfig, tracingInfo} from "../components/KialiController";
+import {distributedTracingPluginConfig, pluginConfig} from "../components/KialiController";
+import {store} from "store/ConfigStore";
 
 export const OSSM_CONSOLE = 'ossmconsole';
 
@@ -170,10 +171,11 @@ export const useInitKialiListeners = (): void => {
                 tenant: pluginConfig.observability.tenant
               };
             } else {
-              observabilityData = parseTempoUrl(tracingInfo.internal_url)
+              const tracingInfo = store.getState().tracingState.info
+              observabilityData = parseTempoUrl(tracingInfo.internalURL)
             }
 
-            if (observabilityData) {
+           if (observabilityData) {
               const trace = urlParams.get('trace');
               if (trace && trace !== "undefined") {
                 consoleUrl = `/observe/traces/${trace}?namespace=${observabilityData.namespace}&name=${observabilityData.instance}&tenant=${observabilityData.tenant}`

--- a/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
+++ b/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
@@ -1,4 +1,4 @@
-import {parseTempoUrl} from "../KialiIntegration";
+import { parseTempoUrl } from '../KialiIntegration';
 
 describe('parseTempoUrl', () => {
   it('should be correct', () => {
@@ -9,7 +9,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample-my-instance');
   });
 
-  it('should return the same array', () => {
+  it('should be correct', () => {
     const url = "http://tempo-sample.tempo.svc.cluster.local:8080/api/traces/v1/default"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toEqual('default');
@@ -17,11 +17,29 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample');
   });
 
-  it('should return the same array', () => {
+  it('should be correct', () => {
     const url = "https://tempo-sample-my-instance.tempo.svc.cluster.local:8080/api/traces/v1/"
     const parsed = parseTempoUrl(url)
-    expect(parsed?.tenant).toBeNull();
+    expect(parsed?.tenant).toBeUndefined();
     expect(parsed?.namespace).toEqual('tempo');
     expect(parsed?.instance).toEqual('sample-my-instance');
   });
+
+  it('should be correct', () => {
+    const url = "http://tempo-sample-query-frontend.tempo.svc:3200"
+    const parsed = parseTempoUrl(url)
+    expect(parsed?.tenant).toBeUndefined();
+    expect(parsed?.instance).toEqual('sample');
+    expect(parsed?.namespace).toEqual('tempo');
+  });
+
+  it('should be correct', () => {
+    const url = "https://tempo-sample-query-frontend.tempo.svc:3200"
+    const parsed = parseTempoUrl(url)
+    expect(parsed?.tenant).toBeUndefined();
+    expect(parsed?.namespace).toEqual('tempo');
+    expect(parsed?.instance).toEqual('sample');
+  });
+
+
 });

--- a/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
+++ b/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
@@ -17,7 +17,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample');
   });
 
-  it('url for multi tenant url for should be correct', () => {
+  it('url for multi tenant url with no tenant should be correct', () => {
     const url = "https://tempo-sample-my-instance.tempo.svc.cluster.local:8080/api/traces/v1/"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toBeUndefined();

--- a/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
+++ b/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
@@ -1,7 +1,7 @@
 import { parseTempoUrl } from '../KialiIntegration';
 
 describe('parseTempoUrl', () => {
-  it('should be correct', () => {
+  it('url for multi tenant should be correct', () => {
     const url = "https://tempo-sample-my-instance-gateway.tempo.svc.cluster.local:8080/api/traces/v1/default"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toEqual('default');
@@ -9,7 +9,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample-my-instance');
   });
 
-  it('should be correct', () => {
+  it('url for multi tenant not secure should be correct', () => {
     const url = "http://tempo-sample.tempo.svc.cluster.local:8080/api/traces/v1/default"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toEqual('default');
@@ -17,7 +17,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample');
   });
 
-  it('should be correct', () => {
+  it('url for multi tenant url for should be correct', () => {
     const url = "https://tempo-sample-my-instance.tempo.svc.cluster.local:8080/api/traces/v1/"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toBeUndefined();
@@ -25,7 +25,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.instance).toEqual('sample-my-instance');
   });
 
-  it('should be correct', () => {
+  it('url for single tenant and http should be correct', () => {
     const url = "http://tempo-sample-query-frontend.tempo.svc:3200"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toBeUndefined();
@@ -33,7 +33,7 @@ describe('parseTempoUrl', () => {
     expect(parsed?.namespace).toEqual('tempo');
   });
 
-  it('should be correct', () => {
+  it('url for single tenant and https should be correct', () => {
     const url = "https://tempo-sample-query-frontend.tempo.svc:3200"
     const parsed = parseTempoUrl(url)
     expect(parsed?.tenant).toBeUndefined();

--- a/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
+++ b/plugin/src/openshift/utils/__tests__/KialiIntegration.test.ts
@@ -1,0 +1,27 @@
+import {parseTempoUrl} from "../KialiIntegration";
+
+describe('parseTempoUrl', () => {
+  it('should be correct', () => {
+    const url = "https://tempo-sample-my-instance-gateway.tempo.svc.cluster.local:8080/api/traces/v1/default"
+    const parsed = parseTempoUrl(url)
+    expect(parsed?.tenant).toEqual('default');
+    expect(parsed?.namespace).toEqual('tempo');
+    expect(parsed?.instance).toEqual('sample-my-instance');
+  });
+
+  it('should return the same array', () => {
+    const url = "http://tempo-sample.tempo.svc.cluster.local:8080/api/traces/v1/default"
+    const parsed = parseTempoUrl(url)
+    expect(parsed?.tenant).toEqual('default');
+    expect(parsed?.namespace).toEqual('tempo');
+    expect(parsed?.instance).toEqual('sample');
+  });
+
+  it('should return the same array', () => {
+    const url = "https://tempo-sample-my-instance.tempo.svc.cluster.local:8080/api/traces/v1/"
+    const parsed = parseTempoUrl(url)
+    expect(parsed?.tenant).toBeNull();
+    expect(parsed?.namespace).toEqual('tempo');
+    expect(parsed?.instance).toEqual('sample-my-instance');
+  });
+});


### PR DESCRIPTION
### Describe the change

- Detects if the Distributed tracing is installed getting the plugin manifest
- When tracing action is sent, it uses the plugin configuration to create and redirect to the tracing plugin.
![image](https://github.com/user-attachments/assets/27a06427-0daa-42ae-85de-fc23aac2ec4a)

### Steps to test the PR

(Note: not really simple to test)

- For testing locally, uncomment distributedTracingPluginConfig setup (Locally, I was not sure how to enable other plugins, even if this is installed). 
- Copy Kiali PR code: https://github.com/kiali/kiali/pull/8265
- Install in OpenShift Kiali with Tempo: 
https://medium.com/kialiproject/installing-openshift-service-mesh-3-tp1-with-kiali-and-grafana-tempo-6b76881ceaef
One tenant name should be "default" to work with the defaults
- Install Distributed tracing UI plugin: 
https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/cluster_observability_operator/observability-ui-plugins#coo-distributed-tracing-ui-plugin-using_distributed-tracing-ui-plugin
- Generate traces
- Go to Kiali UI > See traces from an application. Test that the links are working for "View in tracing" and "More span details" 
![image](https://github.com/user-attachments/assets/cc53736e-5702-4795-81d9-32909f340a77)
![image](https://github.com/user-attachments/assets/6f5c4f71-33d6-4b00-b97c-02c296270b29)
![image](https://github.com/user-attachments/assets/5e12f494-c651-44eb-a75b-3d29ba272234)

### Automation testing

If applicable, explain the case scencarios covered by **e2e** tests created for this PR.

### Issue reference

Ref. https://github.com/kiali/kiali/issues/7904
