### PR TITLE
Change overview request API in the cypress test

### DIFF
--- a/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
+++ b/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
@@ -14,7 +14,7 @@ When('user clicks on the Service Mesh icon in the left navigation bar', () => {
 });
 
 When('cypress intercept hooks for sidebar are registered', () => {
-  cy.intercept(`**/api/istio/validations`).as('overviewRequest');
+  cy.intercept(`**/api/mesh/controlplanes`).as('overviewRequest');
   cy.intercept(`**/api/namespaces`).as('istioConfigRequest');
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
   cy.intercept(`**/api/mesh/graph?*`).as('meshRequest');

--- a/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
+++ b/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
@@ -14,7 +14,7 @@ When('user clicks on the Service Mesh icon in the left navigation bar', () => {
 });
 
 When('cypress intercept hooks for sidebar are registered', () => {
-  cy.intercept(`**/api/istio/status?*`).as('overviewRequest');
+  cy.intercept(`**/api/istio/validations`).as('overviewRequest');
   cy.intercept(`**/api/namespaces`).as('istioConfigRequest');
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
   cy.intercept(`**/api/mesh/graph?*`).as('meshRequest');


### PR DESCRIPTION
### Describe the change

The cypress test `user sees istio-system overview card` does not work anymore because the istio status API is not longer called when OSSMC loads the overview page. This PR calls to istio validations API instead to check that overview page is correctly loaded.

### Steps to test the PR

Verify that CI tests pass
