### PR TITLE
Update path to testdata

### DIFF
--- a/plugin/cypress/integration/openshift/common/hooks.ts
+++ b/plugin/cypress/integration/openshift/common/hooks.ts
@@ -105,7 +105,7 @@ After({ tags: '@clean-istio-namespace-resources-after' }, function () {
 });
 
 Before({ tags: '@shared-mesh-config' }, () => {
-  cy.exec('kubectl apply -f cypress/integration/common/data/istio-shared-mesh-configmap.yaml');
+  cy.exec('kubectl apply -f cypress/integration/kiali/common/data/istio-shared-mesh-configmap.yaml');
   const patch = '{"spec": {"values": {"pilot": {"env": {"SHARED_MESH_CONFIG": "istio-user"}}}}}';
   cy.exec(`kubectl patch istio default --type='merge' -p '${patch}'`).then(() => {
     const maxTries = 10;


### PR DESCRIPTION
### Describe the change

Updates the path to the configmap used in the test. The path is different in OSSMC than in Kiali.

### Steps to test the PR

N/A

### Automation testing

N/A

### Issue reference

Relates to https://github.com/kiali/openshift-servicemesh-plugin/pull/443
