### PR TITLE
Create version branch also on patch releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -260,22 +260,21 @@ jobs:
       run: |
         gh release create $RELEASE_VERSION -t "OpenShift Service Mesh Console $RELEASE_VERSION"
 
-    - name: Create version branch
+    - name: Create or update version branch
       run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
 
     - name: Create a PR to prepare for next version
+      if: ${{ needs.initialize.outputs.release_type == 'minor' || needs.initialize.outputs.release_type == 'major' }}
       env:
         BUILD_TAG: kiali-release-${{ github.run_number }}-${{ needs.initialize.outputs.branch_version }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [[ $RELEASE_TYPE == "major" || $RELEASE_TYPE == "minor" ]]; then
-          hack/update-version-string.sh "${NEXT_VERSION}-SNAPSHOT"
-          
-          git add Makefile plugin/package.json plugin/plugin-metadata.ts
-          
-          git commit -m "Prepare for next version"
-        fi
+        hack/update-version-string.sh "${NEXT_VERSION}-SNAPSHOT"
+        
+        git add Makefile plugin/package.json plugin/plugin-metadata.ts
+        
+        git commit -m "Prepare for next version"
 
         git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
 
-        gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers." -H $BUILD_TAG -B $RELEASE_BRANCH
+        gh pr create -t "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -b "Please, merge to update version numbers." -H $BUILD_TAG -B $RELEASE_BRANCH


### PR DESCRIPTION
OSSMC patch release now creates the version branch similarly to Kiali release action.