### PR TITLE
Release PR title more concise

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -270,11 +270,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         hack/update-version-string.sh "${NEXT_VERSION}-SNAPSHOT"
-        
+
         git add Makefile plugin/package.json plugin/plugin-metadata.ts
-        
+
         git commit -m "Prepare for next version"
 
         git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
 
-        gh pr create -t "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -b "Please, merge to update version numbers." -H $BUILD_TAG -B $RELEASE_BRANCH
+        gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH


### PR DESCRIPTION
### Describe the change

The title of the PR created by the release (e.g., https://github.com/kiali/openshift-servicemesh-plugin/pull/451) is very descriptive (more than the summary). I think the title should be more concise and the summary more descriptive (similar to kiali/kiali in https://github.com/kiali/kiali/pull/8490 for example).
