### PR TITLE
Modify tag-creator to create rc tags

### DIFF
--- a/.github/workflows/tag-creator.yml
+++ b/.github/workflows/tag-creator.yml
@@ -103,6 +103,6 @@ jobs:
           git add plugin/plugin-metadata.ts
         fi
 
-        git commit -m "Release $RELEASE_VERSION"
+        git commit -m "Bump to version $RELEASE_VERSION"
         git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-rc


### PR DESCRIPTION
This PR modify the tag-creator github workflow to create rc (release candidate) tags. In a follow-up PR we will create the possibility to create release candidate tags or final release tags
