### PR TITLE
OSSMC version bumping and release tag creator

### DIFF
--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -1,0 +1,63 @@
+name: Copy Kiali Frontend
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to copy Kiali frontend (Separate branches by commas. Ex v1.73,v2.4)
+        required: true
+        default: v1.73
+        type: string
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ env.branches }}
+    steps:
+    - name: Prepare script to var
+      id: script_convert
+      run: |
+        cat <<-EOF > conversor.py
+        import sys, json
+
+        branch_arg = sys.argv[1]
+        branches = branch_arg.split(',')
+
+        print(json.dumps(branches))
+        EOF
+
+    - name: Set Branch
+      id: branches
+      env:
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+      run: |
+        BRANCHES=$(python conversor.py $TAG_BRANCHES)
+        echo "branches=$BRANCHES" >> $GITHUB_ENV
+
+  copy_kiali:
+    needs: [initialize]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{fromJson(needs.initialize.outputs.branches)}}
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{matrix.branch}}
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+        git config user.name 'kiali-bot'
+
+    - name: Copy Kiali source code
+      env:
+        BRANCH: ${{matrix.branch}}
+      run: |
+        hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
+
+        # Push the changes to the branch
+        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH

--- a/.github/workflows/tag-bump-version.yml
+++ b/.github/workflows/tag-bump-version.yml
@@ -1,12 +1,12 @@
-name: Tag Creator
+name: Tag Bump Version
 
 on:
   workflow_dispatch:
     inputs:
       tag_branch:
-        description: Branch to tag, (Separate branches by commas. Ex v2.4,v1.73)
+        description: Branch to bump version (Separate branches by commas. Ex v1.73,v2.4)
         required: true
-        default: v2.4
+        default: v1.73
         type: string
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
-  create_tag:
+  bump_version:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
@@ -73,7 +73,6 @@ jobs:
     - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
-
         git config user.name 'kiali-bot'
 
     - name: Copy Kiali source code
@@ -82,18 +81,13 @@ jobs:
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
 
-    - name: Create Tag in kiali/openshift-servicemesh-plugin
-      id: tag_ossmc
+    - name: Create Bump Version Tag in kiali/openshift-servicemesh-plugin
       env:
         BRANCH: ${{matrix.branch}}
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        # Remove any pre release identifier (ie: "-SNAPSHOT")
-        RELEASE_VERSION=${RAW_VERSION%-*}
-        RELEASE_VERSION=$(python bump.py patch $RELEASE_VERSION)
-
-        echo "release_version=$RELEASE_VERSION" >> $GITHUB_ENV
+        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
         hack/update-version-string.sh "$RELEASE_VERSION"
 
@@ -103,6 +97,9 @@ jobs:
           git add plugin/plugin-metadata.ts
         fi
 
+        # Commit the changes
         git commit -m "Bump to version $RELEASE_VERSION"
         git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-rc
+
+        # Create the bump version tag
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -80,8 +80,8 @@ jobs:
           echo "Using specified target commit: $TARGET_COMMIT"
         fi
 
-        # Check if commit exists
-        if ! git cat-file -e $TARGET_COMMIT^{commit} 2>/dev/null; then
+        # Check if commit exists in the specified branch
+        if ! git merge-base --is-ancestor $TARGET_COMMIT HEAD 2>/dev/null; then
           echo "Error: Commit $TARGET_COMMIT not found in branch ${{ matrix.branch }}"
           exit 1
         fi

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,0 +1,102 @@
+name: Tag Release Creator
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to tag (Separate branches by commas. Ex v1.73,v2.4)
+        required: true
+        default: v1.73
+        type: string
+      target_commit:
+        description: Commit hash to tag (if empty, uses HEAD of each branch; if specified, requires single branch)
+        required: false
+        type: string
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ env.branches }}
+    steps:
+    - name: Prepare script to var
+      id: script_convert
+      run: |
+        cat <<-EOF > conversor.py
+        import sys, json
+
+        branch_arg = sys.argv[1]
+        branches = branch_arg.split(',')
+
+        print(json.dumps(branches))
+        EOF
+
+    - name: Set Branch
+      id: branches
+      env:
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+      run: |
+        BRANCHES=$(python conversor.py $TAG_BRANCHES)
+        echo "branches=$BRANCHES" >> $GITHUB_ENV
+
+  release_tag:
+    needs: [initialize]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{fromJson(needs.initialize.outputs.branches)}}
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{matrix.branch}}
+        # We need to fetch the full history to check if the commit exists
+        fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+        git config user.name 'kiali-bot'
+
+    - name: Validate target commit
+      run: |
+        # Validate that only single branch is specified when target_commit is provided
+        if [ -n "${{ inputs.target_commit }}" ]; then
+          if [[ "${{ inputs.tag_branch }}" == *","* ]]; then
+            echo "Error: When target_commit is specified, only a single branch is allowed in tag_branch"
+            echo "Provided: ${{ inputs.tag_branch }}"
+            echo "Remove commas and specify only one branch when using a specific commit"
+            exit 1
+          fi
+        fi
+
+        # Set target commit to HEAD if empty
+        if [ -z "${{ inputs.target_commit }}" ]; then
+          TARGET_COMMIT=$(git rev-parse HEAD)
+          echo "No target commit specified, using HEAD: $TARGET_COMMIT"
+        else
+          TARGET_COMMIT="${{ inputs.target_commit }}"
+          echo "Using specified target commit: $TARGET_COMMIT"
+        fi
+
+        # Check if commit exists
+        if ! git cat-file -e $TARGET_COMMIT^{commit} 2>/dev/null; then
+          echo "Error: Commit $TARGET_COMMIT not found in branch ${{ matrix.branch }}"
+          exit 1
+        fi
+
+        echo "Commit $TARGET_COMMIT is valid and exists in branch ${{ matrix.branch }}"
+        echo "TARGET_COMMIT=$TARGET_COMMIT" >> $GITHUB_ENV
+
+    - name: Create Release Tag in kiali/openshift-servicemesh-plugin
+      run: |
+        RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+        echo "Creating release tag $RELEASE_VERSION for commit $TARGET_COMMIT"
+
+        # Create the release tag
+        git push origin $TARGET_COMMIT:refs/tags/$RELEASE_VERSION
+
+        # Delete the bump version tag if it exists
+        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true


### PR DESCRIPTION
### Describe the change

This PR removes previous tag-creator workflow and introduces three GitHub workflows that streamline the OSSMC version bumping and tagging process:

- `tag-bump-version.yaml`
  -  Bump the patch version of release branch
  - Creates the tag `<patch-version>-ossm`

- `tag-release-creator.yaml`
  - Creates the tag `<patch-version>` to specific commit within the release branch
  - Removes the tag `<patch-version>-ossm`

- `copy-kiali-frontend.yaml`
  - Copy the Kiali frontend source code to OSSMC within the release branch

### Steps to test the PR

Testing GitHub workflows in a fork requires some setup and careful planning. Here's a comprehensive guide to test these workflows safely:

1. **Fork Repository & Enable Actions**
```bash
# Fork the repository on GitHub, then clone your fork
git clone https://github.com/YOUR_USERNAME/openshift-servicemesh-plugin.git
cd openshift-servicemesh-plugin

# Add upstream remote
git remote add upstream https://github.com/kiali/openshift-servicemesh-plugin.git
```

2. **Enable GitHub Actions in Your Fork**
- Go to your fork on GitHub
- Navigate to **Settings** → **Actions** → **General**
- Enable "Allow all actions and reusable workflows"

3. **Create Test Branches**
```bash
# Create test branches from existing release branches
git checkout -b test-v2.4 origin/v2.4
git push origin test-v2.4

git checkout -b test-v2.11 origin/v2.11  
git push origin test-v2.11
```
### Testing the Tag Bump Version Workflow

**Test Case 1: Single Branch**
1. Go to **Actions** → **Tag Bump Version** → **Run workflow**
2. Fill inputs:
   ```
   Branch to bump version: test-v2.4
   ```
3. **Expected Results:**
   - New commit with version bump (e.g., v2.4.1)
   - Tag created: `v2.4.1-ossm`
   - `Makefile` and `frontend/package.json` updated

**Test Case 2: Multiple Branches**
1. Run workflow with:
   ```
   Branch to bump version: test-v2.4,test-v2.11
   ```
2. **Expected Results:**
   - Both branches get version bumps
   - Two tags created: `v2.4.1-ossm`, `v2.11.1-ossm`

**Test Case 3: Error Handling**
1. Run with non-existent branch:
   ```
   Branch to bump version: nonexistent-branch
   ```
2. **Expected Results:**
   - Workflow fails with checkout error
   - No tags created

---

### Testing the Tag Release Creator Workflow

**Test Case 1: Valid Commit**
1. First, get a recent commit hash from your test branch:
   ```bash
   git log --oneline test-v2.4 -n 5
   ```
2. Run **Tag Release Creator** workflow:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: [copy a recent commit hash]
   ```
3. **Expected Results:**
   - Clean release tag created (e.g., `v2.4.1`)
   - Corresponding `-ossm` tag removed (if exists)

**Test Case 2: Invalid Commit**
1. Run workflow with:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: invalid123abc
   ```
2. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit

**Test Case 3: Commit from Different Branch**
1. Get commit hash from `main` branch
2. Try to tag it using `test-v2.4` branch
3. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit in that branch

### Cleanup After Testing

**Remove Test Tags**
```bash
# Remove specific tags
git push origin --delete refs/tags/v2.4.1-ossm
git push origin --delete refs/tags/v2.4.1

# Remove all test tags (if following naming pattern)
git ls-remote --tags origin | grep -E "v[0-9]+\.[0-9]+\.[0-9]+" | \
while read hash ref; do
    tag=${ref##*/}
    git push origin --delete refs/tags/$tag
done
```

**Clean Up Test Branches**
```bash
# Remove test branches
git push origin --delete test-v2.4
git push origin --delete test-v2.11

# Clean up local branches
git branch -D test-v2.4 test-v2.11
```
