### PR TITLE
Fix pod handling for workloads without version

### DIFF
--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -25,28 +25,21 @@ const WorkloadMeshTab: React.FC<void> = () => {
   if (ns && name && plural) {
     let workload = name;
     if (plural === 'pods') {
-      let count = 0;
-      let index = 0;
+      const parts = workload.split('-');
 
-      // Get the parent workload (app-version) from pod identifier
-      for (let i = 0; i < workload.length; i++) {
-        if (workload[i] === '-') {
-          count++;
-
-          if (count === 2) {
-            index = i;
-          }
-        }
+      if (parts.length >= 3) {
+        // More than 2 segments -> likely Deployment / ReplicaSet
+        // e.g. details-v1-77b775f46-c7vjb -> details-v1
+        // e.g. istiod-866fd6ccd7-7v8p5 -> istiod
+        workload = parts.slice(0, -2).join('-');
       }
-
-      if (index > 0) {
-        // This is really a guess, but there are pods, like istio, which is like:
-        // istiod-866fd6ccd7-7v8p5 and not details-v1-77b775f46-c7vjb
-        if (count === 2) {
-          index = workload.indexOf(`-`);
-        }
-        workload = workload.substring(0, index);
+      if (parts.length === 2) {
+        // Two segments only -> likely DaemonSet or normal name
+        // e.g. ztunnel-f94gp -> ztunnel
+        workload = parts.slice(0, -1).join('-');
       }
+      // TODO: with hyphen in name (Still an issue)
+      // e.g. kiali-traffic-generator-t9mlw, curl-client
     }
 
     const workloadId: WorkloadId = {

--- a/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
+++ b/plugin/src/openshift/pages/MeshTab/WorkloadMesh.tsx
@@ -24,7 +24,6 @@ const WorkloadMeshTab: React.FC<void> = () => {
 
   if (ns && name && plural) {
     let workload = name;
-
     if (plural === 'pods') {
       let count = 0;
       let index = 0;
@@ -41,6 +40,11 @@ const WorkloadMeshTab: React.FC<void> = () => {
       }
 
       if (index > 0) {
+        // This is really a guess, but there are pods, like istio, which is like:
+        // istiod-866fd6ccd7-7v8p5 and not details-v1-77b775f46-c7vjb
+        if (count === 2) {
+          index = workload.indexOf(`-`);
+        }
         workload = workload.substring(0, index);
       }
     }


### PR DESCRIPTION
### Describe the change

ossmc does a redirection to the workload based on the url pod, but it is not taking into account the pods without the version: 

- istiod-866fd6ccd7-7v8p5
- details-v1-77b775f46-c7vjb

In the case of Istio, tries to look for the workload istiod-866fd6ccd7 which is not found.

### Steps to test the PR

- Run kiali
- Run ossmc, can be run locally: https://github.com/kiali/openshift-servicemesh-plugin/?tab=readme-ov-file#run-the-plugin-and-openshift-console-locally
- Go to a Istio pod, it should work. It should also work for other pod including the version, like the bookinfo

### Automation testing

Url used by ambient tests (In progress)

### Issue reference

Fixes https://github.com/kiali/kiali/issues/8728 
