### PR TITLE
[GH Action] Option to bump to the next version after the tag release creation

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -1,12 +1,19 @@
-name: Tag Bump Version
+name: Bump Release Version
 
 on:
   workflow_dispatch:
     inputs:
-      tag_branch:
-        description: Branch to bump version (Separate branches by commas. Ex v1.73,v2.4)
+      tag_branches:
+        description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73
+        default: v1.73,v2.4,v2.11
+        type: string
+  workflow_call:
+    inputs:
+      tag_branches:
+        description: Branches to bump version (Separate branches by commas)
+        required: true
+        default: v1.73,v2.4,v2.11
         type: string
 
 jobs:
@@ -31,7 +38,7 @@ jobs:
     - name: Set Branch
       id: branches
       env:
-        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branches }}
       run: |
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
@@ -40,13 +47,17 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
+      # Allow other branches to continue even if one of the branches failed
+      fail-fast: false
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
+        # We need to fetch the full history to determine the latest tag
+        fetch-depth: 0
 
     - name: Prepare scripts
       run: |
@@ -75,31 +86,40 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Copy Kiali source code
+    - name: Copy Kiali frontend code
       env:
         BRANCH: ${{matrix.branch}}
       run: |
         hack/copy-frontend-src-to-ossmc.sh --source-ref "$BRANCH"
 
-    - name: Create Bump Version Tag in kiali/openshift-servicemesh-plugin
+    - name: Bump to next version
       env:
         BRANCH: ${{matrix.branch}}
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
+        LATEST_TAG=$(git describe --tags --abbrev=0)
 
-        hack/update-version-string.sh "$RELEASE_VERSION"
+        # Check if the latest tag is the current release version tag
+        if [[ "$LATEST_TAG" == "$RAW_VERSION" ]]; then
+          RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
-        git add Makefile plugin/package.json
+          # Update the version in OSSMC repository
+          hack/update-version-string.sh "$RELEASE_VERSION"
 
-        if [[ $BRANCH != "v1.73" ]]; then
-          git add plugin/plugin-metadata.ts
+          # Commit the changes
+          git add Makefile plugin/package.json
+
+          if [[ $BRANCH != "v1.73" ]]; then
+            git add plugin/plugin-metadata.ts
+          fi
+
+          git commit -m "Bump to version $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+
+          # Create the ossm version tag
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+        else
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RAW_VERSION tag"
+          exit 1
         fi
-
-        # Commit the changes
-        git commit -m "Bump to version $RELEASE_VERSION"
-        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
-
-        # Create the bump version tag
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm

--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -3,8 +3,8 @@ name: Copy Kiali Frontend
 on:
   workflow_dispatch:
     inputs:
-      tag_branches:
-        description: Branches to bump version (Separate branches by commas)
+      branches:
+        description: Branches to copy Kiali frontend (Separate branches by commas)
         required: true
         default: v1.73,v2.4,v2.11
         type: string
@@ -31,9 +31,9 @@ jobs:
     - name: Set Branch
       id: branches
       env:
-        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        BRANCHES: ${{ github.event.inputs.branches }}
       run: |
-        BRANCHES=$(python conversor.py $TAG_BRANCHES)
+        BRANCHES=$(python conversor.py $BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
 
   copy_kiali:
@@ -44,7 +44,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
 

--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -3,10 +3,10 @@ name: Copy Kiali Frontend
 on:
   workflow_dispatch:
     inputs:
-      tag_branch:
-        description: Branch to copy Kiali frontend (Separate branches by commas. Ex v1.73,v2.4)
+      tag_branches:
+        description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73
+        default: v1.73,v2.4,v2.11
         type: string
 
 jobs:

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,17 +1,18 @@
-name: Tag Release Creator
+name: Release Tag Creator
 
 on:
   workflow_dispatch:
     inputs:
-      tag_branch:
-        description: Branch to tag (Separate branches by commas. Ex v1.73,v2.4)
+      tag_branches:
+        description: Branches to tag (Separate branches by commas)
         required: true
-        default: v1.73
+        default: v1.73,v2.4,v2.11
         type: string
-      target_commit:
-        description: Commit hash to tag (if empty, uses HEAD of each branch; if specified, requires single branch)
-        required: false
-        type: string
+      bump_next_version:
+        description: Bump to next version after creating release tag
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   initialize:
@@ -35,7 +36,7 @@ jobs:
     - name: Set Branch
       id: branches
       env:
-        TAG_BRANCHES: ${{ github.event.inputs.tag_branch }}
+        TAG_BRANCHES: ${{ github.event.inputs.tag_branches }}
       run: |
         BRANCHES=$(python conversor.py $TAG_BRANCHES)
         echo "branches=$BRANCHES" >> $GITHUB_ENV
@@ -44,14 +45,16 @@ jobs:
     needs: [initialize]
     runs-on: ubuntu-latest
     strategy:
+      # Allow other branches to continue even if one of the branches failed
+      fail-fast: false
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{matrix.branch}}
-        # We need to fetch the full history to check if the commit exists
+        # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 
     - name: Configure git
@@ -59,44 +62,31 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Validate target commit
-      run: |
-        # Validate that only single branch is specified when target_commit is provided
-        if [ -n "${{ inputs.target_commit }}" ]; then
-          if [[ "${{ inputs.tag_branch }}" == *","* ]]; then
-            echo "Error: When target_commit is specified, only a single branch is allowed in tag_branch"
-            echo "Provided: ${{ inputs.tag_branch }}"
-            echo "Remove commas and specify only one branch when using a specific commit"
-            exit 1
-          fi
-        fi
-
-        # Set target commit to HEAD if empty
-        if [ -z "${{ inputs.target_commit }}" ]; then
-          TARGET_COMMIT=$(git rev-parse HEAD)
-          echo "No target commit specified, using HEAD: $TARGET_COMMIT"
-        else
-          TARGET_COMMIT="${{ inputs.target_commit }}"
-          echo "Using specified target commit: $TARGET_COMMIT"
-        fi
-
-        # Check if commit exists in the specified branch
-        if ! git merge-base --is-ancestor $TARGET_COMMIT HEAD 2>/dev/null; then
-          echo "Error: Commit $TARGET_COMMIT not found in branch ${{ matrix.branch }}"
-          exit 1
-        fi
-
-        echo "Commit $TARGET_COMMIT is valid and exists in branch ${{ matrix.branch }}"
-        echo "TARGET_COMMIT=$TARGET_COMMIT" >> $GITHUB_ENV
-
     - name: Create Release Tag in kiali/openshift-servicemesh-plugin
       run: |
         RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        echo "Creating release tag $RELEASE_VERSION for commit $TARGET_COMMIT"
+        LATEST_TAG=$(git describe --tags --abbrev=0)
 
-        # Create the release tag
-        git push origin $TARGET_COMMIT:refs/tags/$RELEASE_VERSION
+        # Check if the latest tag is the current ossm version tag
+        if [[ "$LATEST_TAG" == "$RELEASE_VERSION-ossm" ]]; then
+          # Delete the ossm version tag
+          echo "Deleting existing ossm version tag: $RELEASE_VERSION-ossm"
+          git push origin --delete refs/tags/$RELEASE_VERSION-ossm
 
-        # Delete the bump version tag if it exists
-        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true
+          # Create the release tag
+          echo "Creating release tag $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        else
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RELEASE_VERSION-ossm tag"
+          exit 1
+        fi
+
+  bump_version:
+    name: Bump to Next Version
+    needs: [initialize, release_tag]
+    # Allow other branches to bump to the next version even if one of the branches failed to create the release tag
+    if: ${{ inputs.bump_next_version && always() }}
+    uses: ./.github/workflows/bump-release-version.yml
+    with:
+      tag_branches: ${{ inputs.tag_branches }}


### PR DESCRIPTION
### Describe the change

This PR enhances the tag release creation workflow by adding functionality to automatically bump to the next version after creating a release tag. Additionally, the latest tag of the branch is analyzed to verify if it is the expected one to avoid errors during the workflow.
