### PR TITLE
Add test image and creation workflow

### DIFF
--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -1,0 +1,70 @@
+name: Build and push test suite images
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: Branch to release
+        default: master
+        type: string
+        required: true
+      quay_org:
+        description: Quay organization
+        type: string
+        default: kiali
+        required: true
+      images_tag:
+        description: Images tag
+        type: string
+        default: dev
+        required: true
+  workflow_call:
+    inputs:
+      release_branch:
+        description: Branch to release
+        type: string
+        required: true
+      quay_org:
+        description: Quay organization
+        type: string
+        required: true
+      images_tag:
+        description: Images tag
+        type: string
+        required: true
+    secrets:
+      QUAY_USER:
+        description: 'A quay user secret passed from the caller workflow'
+        required: true
+      QUAY_PASSWORD:
+        description: 'A quay user password passed from the caller workflow'
+        required: true
+
+
+jobs:
+  build_and_push_cypress_tests:
+    name: Generate and push ossmc cypress test docker images
+    runs-on: ubuntu-latest
+    env:
+      # These ENVs are expected in Make file!
+      IMAGE_ORG: ${{ inputs.quay_org }}
+      CYPRESS_TESTS_CONTAINER_VERSION: ${{ inputs.images_tag }}
+    steps:
+    - name: Log information
+      run: |
+        echo "Branch": ${{ inputs.release_branch }}
+        echo "Quay organization": ${{ inputs.quay_org }}
+        echo "Images tag": ${{ inputs.images_tag }}
+    - name: Checkout code
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.release_branch }}
+    - name: Login to Quay.io
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: "Build cypress test image"
+      run: |
+        make container-build-cypress-tests container-push-cypress-tests-quay

--- a/.github/workflows/test-images-update-latest.yml
+++ b/.github/workflows/test-images-update-latest.yml
@@ -1,0 +1,24 @@
+name: Update latest test suite images
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'hack/**'
+    - 'plugin/**'
+    # ignore src folder
+    - '!plugin/src/**'
+    - 'deploy/docker/Dockerfile-cypress'
+
+jobs:
+  push_test_images:
+    name: Build and push test images
+    uses: ./.github/workflows/test-images-creator.yml
+    with:
+      release_branch: ${{ github.ref_name }}
+      images_tag: 'latest'
+      quay_org: 'kiali'
+    secrets:
+      QUAY_USER: ${{ secrets.QUAY_USER }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,19 @@ ARCH := $(shell uname -m | sed 's/x86_64/amd64/')
 # Container version used when tagging container images
 # When doing releases, you probably want to override this so it is set to the release version string.
 CONTAINER_VERSION ?= dev
+# Identifies the Kiali container image that will be built.
+IMAGE_ORG ?= kiali
+CONTAINER_NAME ?= ${IMAGE_ORG}/kiali
+
+# Identifies the Kiali OSSMC cypress tests container image that will be built
+CYPRESS_TESTS_CONTAINER_NAME ?= ${IMAGE_ORG}/kiali-ossmc-cypress-tests
+CYPRESS_TESTS_CONTAINER_VERSION ?= ${CONTAINER_VERSION}
+CYPRESS_TESTS_QUAY_NAME ?= quay.io/${CYPRESS_TESTS_CONTAINER_NAME}
+CYPRESS_TESTS_QUAY_TAG ?= ${CYPRESS_TESTS_QUAY_NAME}:${CYPRESS_TESTS_CONTAINER_VERSION}
 
 include make/Makefile.plugin.mk
 include make/Makefile.cluster.mk
+include make/Makefile.container.mk
 
 help:
 	@echo

--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -1,0 +1,40 @@
+# don't forget to pass environmet variables to docker run like this:
+# podman run -e CYPRESS_BASE_URL=<OCP_URL> -e CYPRESS_USERNAME=<username> -e CYPRESS_PASSWD=<passwd> quay.io/kiali/kiali-ossmc-cypress-tests:dev
+# more details here https://github.com/kiali/openshift-servicemesh-plugin/tree/main/plugin/cypress
+
+# using same baseimage of node as its defined in package.json
+FROM cypress/base:20.16.0
+
+# we need to set HOME when running on OCP with random UID, otherwise the home is set to / and any writing there will fail with permission denied
+ENV HOME=/tmp/kiali
+
+# install required packages and oc bin
+WORKDIR /usr/bin
+RUN apt -y update && \
+    apt install -y tar gzip bash gettext curl && \
+    apt-get clean && \
+    curl -Lo ./oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz && \
+    tar -xf oc.tar.gz && \
+    rm -f oc.tar.gz
+
+# copy also hack scripts which will be used to install demo apps
+COPY hack $HOME/hack
+COPY plugin/ $HOME/
+
+WORKDIR $HOME
+
+# Use cypress cache in home folder, not under root
+RUN mkdir .cache
+ENV CYPRESS_CACHE_FOLDER=$HOME/.cache
+
+# Install Cypress dependencies.
+RUN yarn install --frozen-lockfile
+
+# Set required permissions for OpenShift usage
+RUN chgrp -R 0 $HOME && \
+    chmod -R g=u $HOME
+
+ENV TEST_GROUP="@ossmc"
+
+# Run Cypress tests.
+CMD ["yarn", "cypress:run:test-group:junit"]

--- a/make/Makefile.container.mk
+++ b/make/Makefile.container.mk
@@ -1,0 +1,36 @@
+#
+# These targets build the containers without any cluster environment in mind.
+# Instead, the containers built are tagged for publishing to quay.io and/or docker.io.
+#
+
+## container-build-cypress-tests: Build Kiali cypress tests container image
+container-build-cypress-tests:
+	@OSSMC_BRANCH=$${OSSMC_BRANCH:-$$(git rev-parse --abbrev-ref HEAD)}; \
+	echo "OSSMC_BRANCH: $$OSSMC_BRANCH"; \
+	if echo "$$OSSMC_BRANCH" | grep -qE '^v[0-9]+\.[0-9]+'; then \
+		echo "OSSMC release branch $$OSSMC_BRANCH"; \
+		KIALI_BRANCH=$$OSSMC_BRANCH; \
+	else \
+		echo "This branch is not an OSSMC release branch (v*.*)! Using master for Kiali source code branch"; \
+		KIALI_BRANCH=master; \
+	fi; \
+	echo "KIALI_BRANCH: $$KIALI_BRANCH"; \
+	./hack/copy-frontend-src-to-ossmc.sh --source-ref "$$KIALI_BRANCH"; \
+	./hack/download-hack-scripts.sh --kiali-branch "$$KIALI_BRANCH"
+ifeq ($(DORP),docker)
+	@echo Building container image for Kiali cypress tests using docker
+	docker build --pull -t ${CYPRESS_TESTS_QUAY_TAG} -f deploy/docker/Dockerfile-cypress .
+else
+	@echo Building container image for Kiali cypress tests using podman
+	podman build --pull -t ${CYPRESS_TESTS_QUAY_TAG} -f deploy/docker/Dockerfile-cypress .
+endif
+
+## container-push-cypress-tests-quay: Pushes the Kiali cypress test image to quay.
+container-push-cypress-tests-quay:
+ifeq ($(DORP),docker)
+	@echo Pushing Kiali cypress test image to ${CYPRESS_TESTS_QUAY_TAG} using docker
+	docker push ${CYPRESS_TESTS_QUAY_TAG}
+else
+	@echo Pushing Kiali cypress test image to ${CYPRESS_TESTS_QUAY_TAG} using podman
+	podman push ${CYPRESS_TESTS_QUAY_TAG}
+endif


### PR DESCRIPTION
### Describe the change
Feature Request: https://github.com/kiali/openshift-servicemesh-plugin/issues/503

-  Added Dockerfile for test image
-  Added Makefile targets for generating and pushing the test image
-  Added GitHub workflows to generate a test image:
     - manually for a particular version
     - automatically under the latest tag with related changes committed in the main branch

**Verified on my fork:**
- Auto trigger when something was change in relevant code
  - change commit to master: https://github.com/mkralik3/openshift-servicemesh-plugin/commit/27a30acb74ba5aa3c1f9a4b7faec5c6c0cd97fcc
  - GH Action https://github.com/mkralik3/openshift-servicemesh-plugin/actions/runs/18594985182
  - `latest` image: quay.io/mkralik3/kiali-ossmc-cypress-tests:latest
  ```
  podman run -it --entrypoint /bin/bash quay.io/mkralik3/kiali-ossmc-cypress-tests:latest
  root@02b9b5dc3375:~# cat plugin-metadata.ts  | grep version
  version: '2.18.0',
  ```
- Manual trigger a particular version (v2.11) creation 
  - GH Action https://github.com/mkralik3/openshift-servicemesh-plugin/actions/runs/18594199884 
  - Image: quay.io/mkralik3/kiali-ossmc-cypress-tests:v2.11
  ```
  podman run -it --entrypoint /bin/bash quay.io/mkralik3/kiali-ossmc-cypress-tests:v2.11
  root@211440cb626a:~# cat plugin-metadata.ts  | grep version
  version: '2.11.4'
  ```