### PR TITLE
Fixed Mesh name check in cypress

### DIFF
--- a/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
+++ b/plugin/cypress/integration/openshift/common/sidebar_navigation.ts
@@ -98,9 +98,13 @@ Then('user sees the mesh side panel', () => {
       .within(() => {
         const resp = interception.response;
         expect(resp?.statusCode).to.eq(200);
-        expect(resp?.body.meshName).to.not.equal(undefined);
-        expect(resp?.body.meshName).to.not.equal('');
-        cy.contains(`Mesh: ${resp?.body.meshName}`);
+        expect(resp?.body.meshNames).to.not.equal(null);
+        expect(resp?.body.meshNames.length).to.be.greaterThan(0);
+        expect(resp?.body.meshNames).to.not.include('');
+        // Check that each mesh name is displayed in the UI
+        resp?.body.meshNames.forEach((meshName: string) => {
+          cy.contains(`Mesh: ${meshName}`);
+        });
       });
   });
 });


### PR DESCRIPTION
### Describe the change

Fixing failing cypress test: `OSSMC.Kiali sidebar integration with OCP Console.Mesh page is displayed correctly`
Backport of Kiali mesh name fix:
https://github.com/kiali/kiali/pull/8709/files#diff-cef6c605477330069180d9ed751e87a8e8aff193bf4e3314c2c0c7c0f1497661R108
