### PR TITLE
Copy of Kiali frontend source code

### DIFF
--- a/plugin/src/kiali/README.md
+++ b/plugin/src/kiali/README.md
@@ -3,5 +3,5 @@
 Copy of Kiali frontend source code
 Kiali frontend source originated from:
 * git ref:    master
-* git commit: a0b93fb6084e5fdf4899215c2be0531fe40ec955
-* GitHub URL: https://github.com/kiali/kiali/tree/a0b93fb6084e5fdf4899215c2be0531fe40ec955/frontend/src
+* git commit: 56d6f1151adb0275c71dc7d7bfa29070a5ccb07b
+* GitHub URL: https://github.com/kiali/kiali/tree/56d6f1151adb0275c71dc7d7bfa29070a5ccb07b/frontend/src

--- a/plugin/src/kiali/pages/Graph/SummaryPanelNode.tsx
+++ b/plugin/src/kiali/pages/Graph/SummaryPanelNode.tsx
@@ -138,7 +138,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
     const shouldRenderApp = app && ![NodeType.APP, NodeType.UNKNOWN].includes(nodeType) && !nodeData.isWaypoint;
     const shouldRenderWorkload = workload && ![NodeType.WORKLOAD, NodeType.UNKNOWN].includes(nodeType);
     const shouldRenderNetobservWorkload = hasNetobserv && (nodeType === NodeType.WORKLOAD || shouldRenderWorkload);
-    const shouldRenderNetobservService = hasNetobserv && (nodeType === NodeType.SERVICE || shouldRenderService);
     const shouldRenderTraces =
       !isServiceEntry &&
       !nodeData.isInaccessible &&
@@ -252,7 +251,6 @@ export class SummaryPanelNodeComponent extends React.Component<SummaryPanelNodeC
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}
             {shouldRenderApp && <div>{renderBadgedLink(nodeData, NodeType.APP)}</div>}
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
-            {shouldRenderNetobservService && this.renderNetobservLink(nodeData, NodeType.SERVICE)}
             {shouldRenderNetobservWorkload && this.renderNetobservLink(nodeData, NodeType.WORKLOAD)}
           </div>
         </div>


### PR DESCRIPTION
Kiali frontend source originated from:
* git ref:    master
* git commit: 56d6f1151adb0275c71dc7d7bfa29070a5ccb07b
* GitHub URL: https://github.com/kiali/kiali/tree/56d6f1151adb0275c71dc7d7bfa29070a5ccb07b/frontend/src

related-to: https://github.com/kiali/openshift-servicemesh-plugin/issues/507
- Supports a slight change in strategy for Netobserv linking