### PR TITLE
Netobserv link in the graph side panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ At this point, the OpenShift Console will start and be accessible at http://loca
 
 ### Testing Locally Distributed Tracing integration
 
-For testing the distributed tracing integration locally, assign to distributedTracingPluginConfig in the getDistributedTracingPluginManifestPromise in the KialiController the following data: 
+For testing the distributed tracing integration locally, assign to distributedTracingPluginConfig in the getDistributedTracingPluginManifestPromise in the KialiController the following data:
 
 ```sh
   distributedTracingPluginConfig = {
@@ -126,7 +126,49 @@ For testing the distributed tracing integration locally, assign to distributedTr
   }
 ```
 
-That will help to validate if the logic and the URL are right, but in the localhost plugin it won't load the distributed tracing plugin page. 
+That will help to validate if the logic and the URL are right, but in the localhost plugin it won't load the distributed tracing plugin page.
+
+### Testing Locally Netobserv integration
+
+For testing the Netobserv integration locally, assign to netobservPluginConfig in the getNetobservPluginManifestPromise in the KialiController.go, the following data:
+
+```sh
+  netobservPluginConfig = {
+    "name": "network-observability-console-plugin",
+    "version": "0.0.1",
+    "displayName": "Network Observability Plugin",
+    "description": "This plugin adds a network observability UI to the OpenShift console.",
+    "dependencies": {
+      "@console/pluginAPI": "*"
+    },
+    "extensions": [
+      {
+        "type": "console.page/route",
+        "properties": {
+           "exact": false,
+           "path": "/observe/network-traffic",
+            "component": {
+              "$codeRef": "NetworkTrafficUI"
+            }
+          }
+      },
+      {
+        "type": "console.navigation/href",
+        "properties": {
+          "id": "network-observability",
+          "name": "Network Traffic",
+          "href": "/observe/network-traffic",
+          "perspective": "admin",
+           "section": "observe"
+        }
+      }
+    ]
+  };
+```
+
+That will help to validate if the logic and the URL are right, but in the localhost plugin it won't load the Network Observability plugin page.
+
+````
 
 ## Operator
 
@@ -152,7 +194,7 @@ To build and release the plugin, you can run this command either manually or ins
 
 ```sh
 make -e CONTAINER_VERSION=v0.1.0 build-plugin-image push-plugin-image
-```
+````
 
 Or for a multi-arch container:
 

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -1,39 +1,40 @@
 import * as React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
-import {Namespace} from 'types/Namespace';
-import {MessageType} from 'types/MessageCenter';
-import {DurationInSeconds, IntervalInMilliseconds, PF_THEME_DARK, Theme} from 'types/Common';
-import {TracingInfo} from 'types/TracingInfo';
-import {toGrpcRate, toHttpRate, toTcpRate, TrafficRate} from 'types/Graph';
-import {StatusKey, StatusState} from 'types/StatusState';
-import {PromisesRegistry} from 'utils/CancelablePromises';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Namespace } from 'types/Namespace';
+import { MessageType } from 'types/MessageCenter';
+import { DurationInSeconds, IntervalInMilliseconds, PF_THEME_DARK, Theme } from 'types/Common';
+import { TracingInfo } from 'types/TracingInfo';
+import { toGrpcRate, toHttpRate, toTcpRate, TrafficRate } from 'types/Graph';
+import { StatusKey, StatusState } from 'types/StatusState';
+import { PromisesRegistry } from 'utils/CancelablePromises';
 import * as API from 'services/Api';
 import * as AlertUtils from 'utils/AlertUtils';
-import {humanDurations, serverConfig, setServerConfig} from 'config/ServerConfig';
-import {config} from 'config';
-import {KialiDispatch} from 'types/Redux';
-import {MessageCenterActions} from 'actions/MessageCenterActions';
-import {LoginThunkActions} from 'actions/LoginThunkActions';
-import {NamespaceActions} from 'actions/NamespaceAction';
-import {UserSettingsActions} from 'actions/UserSettingsActions';
-import {TracingActions} from 'actions/TracingActions';
-import {LoginActions} from 'actions/LoginActions';
-import {GraphToolbarActions} from 'actions/GraphToolbarActions';
-import {HelpDropdownActions} from 'actions/HelpDropdownActions';
-import {GlobalActions} from 'actions/GlobalActions';
+import { humanDurations, serverConfig, setServerConfig } from 'config/ServerConfig';
+import { config } from 'config';
+import { KialiDispatch } from 'types/Redux';
+import { MessageCenterActions } from 'actions/MessageCenterActions';
+import { LoginThunkActions } from 'actions/LoginThunkActions';
+import { NamespaceActions } from 'actions/NamespaceAction';
+import { UserSettingsActions } from 'actions/UserSettingsActions';
+import { TracingActions } from 'actions/TracingActions';
+import { LoginActions } from 'actions/LoginActions';
+import { GraphToolbarActions } from 'actions/GraphToolbarActions';
+import { HelpDropdownActions } from 'actions/HelpDropdownActions';
+import { GlobalActions } from 'actions/GlobalActions';
 import {
   getDistributedTracingPluginManifest,
+  getNetobservPluginManifest,
   getPluginConfig,
   OpenShiftPluginConfig,
   PluginConfig
 } from 'openshift/utils/KialiIntegration';
-import {MeshTlsActions} from 'actions/MeshTlsActions';
-import {TLSStatus} from 'types/TLSStatus';
-import {IstioCertsInfoActions} from 'actions/IstioCertsInfoActions';
-import {CertsInfo} from 'types/CertsInfo';
-import {store} from 'store/ConfigStore';
-import {kialiStyle} from 'styles/StyleUtils';
+import { MeshTlsActions } from 'actions/MeshTlsActions';
+import { TLSStatus } from 'types/TLSStatus';
+import { IstioCertsInfoActions } from 'actions/IstioCertsInfoActions';
+import { CertsInfo } from 'types/CertsInfo';
+import { store } from 'store/ConfigStore';
+import { kialiStyle } from 'styles/StyleUtils';
 
 declare global {
   interface Date {
@@ -84,10 +85,13 @@ const defaultPluginConfig: PluginConfig = {
 };
 
 let pluginConfig: PluginConfig = defaultPluginConfig;
-export {pluginConfig};
+export { pluginConfig };
 
-let distributedTracingPluginConfig:OpenShiftPluginConfig;
-export {distributedTracingPluginConfig};
+let distributedTracingPluginConfig: OpenShiftPluginConfig;
+export { distributedTracingPluginConfig };
+
+let netobservPluginConfig: any;
+export { netobservPluginConfig };
 
 class KialiControllerComponent extends React.Component<KialiControllerProps> {
   private promises = new PromisesRegistry();
@@ -151,7 +155,7 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
 
       const getPluginPromise = this.promises
         .register('getPluginPromise', getPluginConfig())
-        .then(response => {pluginConfig = response})
+        .then(response => { pluginConfig = response })
         .catch(error => {
           AlertUtils.addError('Error fetching plugin configuration.', error, 'default', MessageType.WARNING);
         });
@@ -162,6 +166,13 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
         .catch(error => {
           console.debug(`Error fetching Distributed Tracing plugin configuration. (Probably is not installed) ${error}`)
           // For testing the distributed tracing integration locally, assign distributedTracingPluginConfig = "plugin manifest json"
+        });
+      const getNetobservPluginManifestPromise = this.promises
+        .register('getNetobservPluginManifestPromise', getNetobservPluginManifest())
+        .then(response => (netobservPluginConfig = (response)))
+        .catch(error => {
+          console.debug(`Failed to fetch Netobserv plugin configuration (plugin is not probably installed). ${error}`)
+          // For testing the netobserv integration locally, assign netobservPluginConfig = "plugin manifest json"
         });
       API.getStatus()
         .then(response => this.processServerStatus(response.data))
@@ -174,8 +185,12 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
         getServerConfigPromise,
         getTracingInfoPromise,
         getPluginPromise,
-        getDistributedTracingPluginManifestPromise
-      ]);
+        getDistributedTracingPluginManifestPromise,
+        getNetobservPluginManifestPromise
+      ]).then(() => {
+        // Set kiosk data for OSSMC
+        store.dispatch(GlobalActions.setKioskData({ hasExternalTracing: !!distributedTracingPluginConfig, hasNetobserv: !!netobservPluginConfig }));
+      });
     } catch (err) {
       console.error('Error loading kiali config', err);
     }
@@ -311,4 +326,7 @@ const mapDispatchToProps = (dispatch: KialiDispatch): KialiControllerReduxProps 
   statusRefresh: bindActionCreators(HelpDropdownActions.statusRefresh, dispatch)
 });
 
-export const KialiController = connect(null, mapDispatchToProps)(KialiControllerComponent);
+export const KialiController = connect(
+  null,
+  mapDispatchToProps
+)(KialiControllerComponent);


### PR DESCRIPTION
This is just a squashed version of Mayleigh's original PR 484: https://github.com/kiali/openshift-servicemesh-plugin/pull/484. That PR was merged, not squash merged, which made it hard to to backport easily to 2.17. So, it wqas reverted, and replaced by this. No code changes, just changing commit style.

Added a badge inside the Traffic Graph page that is labeled Network Traffic. It links to the Deployment Network traffic tab, if Netobserv is installed and it registers traffic for the workload.
