### PR TITLE
Disable scheduled releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  schedule:
+  # schedule:
   # Every Tuesday at 01:00 (UTC) which is the day after the server release is done. This action takes several hours to complete.
-  - cron: "00 1 * * TUE"
+  # - cron: "00 1 * * TUE"
   workflow_dispatch:
     inputs:
       release_type:


### PR DESCRIPTION
### Describe the change

Due to the upcoming Christmas holidays, the release schedule for Kiali will be modified slightly. For this reason, the three-week schedule for the cron job has been disabled in the Release GitHub Action