### PR TITLE
Enable schedule for automatic releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  # schedule:
+  schedule:
   # Every Tuesday at 01:00 (UTC) which is the day after the server release is done. This action takes several hours to complete.
-  # - cron: "00 1 * * TUE"
+  - cron: "00 1 * * TUE"
   workflow_dispatch:
     inputs:
       release_type:
@@ -11,9 +11,9 @@ on:
         required: true
         type: choice
         options:
-        - major
-        - minor
         - patch
+        - minor
+        - major
       release_branch:
         description: Branch to release
         required: true
@@ -72,7 +72,8 @@ jobs:
         cat <<-EOF > minor.py
         import datetime
 
-        base = int(datetime.datetime.strptime("24/04/2022", "%d/%m/%Y").timestamp())
+        # The base date is set so that releases occur every 3 weeks starting from January 26, 2026
+        base = int(datetime.datetime.strptime("26/01/2026", "%d/%m/%Y").timestamp())
         now = int(datetime.datetime.now().timestamp())
 
         diff = now - base
@@ -81,7 +82,8 @@ jobs:
         weeks_elapsed = int(days_elapsed / 7)
         weeks_mod3 = int(weeks_elapsed % 3)
 
-        print(weeks_mod3)
+        # Only release when weeks_elapsed >= 0 (past the base date) and weeks_mod3 == 0
+        print(weeks_elapsed >= 0 and weeks_mod3 == 0) # True in case of release
         EOF
 
     - name: Determine release type
@@ -90,7 +92,7 @@ jobs:
         if [ -z ${{ github.event.inputs.release_type }} ];
         then
           DO_RELEASE=$(python minor.py)
-          if [[ $DO_RELEASE == "1" ]]
+          if [[ $DO_RELEASE == "True" ]]
           then
             echo "release_type=minor" >> $GITHUB_ENV
           else


### PR DESCRIPTION
### Describe the change

Enable schedule for automatic releases again, setting the base date is set so that releases occur every 3 weeks starting from January 26, 2026.

Additionally, I have switched the order of release type options so that the default option is `patch`, the most common release type used for manual releases.
