### PR TITLE
Upgrade Node.js from 20 to 24

### DIFF
--- a/deploy/docker/Dockerfile-cypress
+++ b/deploy/docker/Dockerfile-cypress
@@ -3,7 +3,7 @@
 # more details here https://github.com/kiali/openshift-servicemesh-plugin/tree/main/plugin/cypress
 
 # using same baseimage of node as its defined in package.json
-FROM cypress/base:20.16.0
+FROM cypress/base:24.0.0
 
 # we need to set HOME when running on OCP with random UID, otherwise the home is set to / and any writing there will fail with permission denied
 ENV HOME=/tmp/kiali

--- a/plugin/Dockerfile
+++ b/plugin/Dockerfile
@@ -1,4 +1,4 @@
-FROM  registry.access.redhat.com/ubi8/nodejs-20 AS build
+FROM  registry.access.redhat.com/ubi9/nodejs-24 AS build
 
 USER root
 RUN command -v yarn || npm i -g yarn

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -92,7 +92,7 @@
     "@types/jest": "23.3.10",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash-es": "4.17.x",
-    "@types/node": "^20.14.9",
+    "@types/node": "^24.0.0",
     "@types/react": "^17.0.1",
     "@types/react-copy-to-clipboard": "^5.0.7",
     "@types/react-dom": "^17.0.1",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -147,7 +147,7 @@
     "webpack": "^5.104.1"
   },
   "engines": {
-    "node": ">=20.6.0",
+    "node": ">=24.0.0",
     "yarn": ">=1.0.0"
   },
   "cypress-cucumber-preprocessor": {

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "lib": ["es2019", "dom"],
+    "lib": ["es2022", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -2996,12 +2996,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^20.14.9":
-  version "20.16.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.5.tgz#d43c7f973b32ffdf9aa7bd4f80e1072310fd7a53"
-  integrity sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==
+"@types/node@^24.0.0":
+  version "24.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.0.tgz#6222e028210e5322e4f4f6767f8d88e5ea3b33d2"
+  integrity sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~7.16.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -12115,11 +12115,6 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici-types@~7.16.0:
   version "7.16.0"


### PR DESCRIPTION
### Describe the change

- Upgrade Node.js version requirement from 20 to 24 across the project
- Update Cypress Docker base image to use Node.js 24
- Update ubi base image in Dockerfile to use Node.js 24

### Steps to test the PR

Verify CI workflows pass on the PR

### Issue reference

Closes https://github.com/kiali/kiali/issues/9328
