### PR TITLE
[v1.73] Add multi-arch CPU support to Yarn .yarnrc.yml configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       target_branch: ${{ env.target_branch }}
       build_branch: ${{ env.build_branch }}
@@ -53,7 +53,7 @@ jobs:
 
   build_plugin:
     name: Build plugin
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [initialize]
     steps:
     - name: Checkout code

--- a/plugin/.yarnrc.yml
+++ b/plugin/.yarnrc.yml
@@ -1,2 +1,9 @@
 enableTelemetry: false
 nodeLinker: node-modules
+supportedArchitectures:
+  cpu:
+  - current
+  - x64
+  - arm64
+  - ppc64
+  - s390x


### PR DESCRIPTION
### Describe the change

Backport of #624 to v1.73.

Adds supportedArchitectures.cpu to .yarnrc.yml so that Yarn Berry prefetches platform-specific dependencies for all build target architectures (x64, arm64, ppc64, s390x).

For downstream builds, the yarn install step fails on arm64 with getaddrinfo ENOTFOUND registry.yarnpkg.com because platform-specific conditional dependencies (e.g., @esbuild/linux-arm64) are not available in the prefetch cache. The prefetch task runs on x86_64 and Yarn only downloads packages for the current CPU by default.

### Steps to test the PR

This change only affects downstream, verify CI tests pass upstream.

Made with [Cursor](https://cursor.com)