### PR TITLE
[v2.22] Upgrade axios to 1.15.1+ to fix CVE-2026-42035

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -43,7 +43,7 @@
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
     "@patternfly/react-topology": "^6.4.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "bootstrap-slider-without-jquery": "10.0.0",
     "deep-freeze": "0.0.1",
     "eventemitter3": "4.0.7",

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -5527,14 +5527,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.15.1":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
     follow-redirects: "npm:^1.15.11"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 
@@ -13382,7 +13382,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.0.0"
     "@typescript-eslint/parser": "npm:^7.0.0"
     "@wojtekmaj/enzyme-adapter-react-17": "npm:^0.6.7"
-    axios: "npm:^1.15.0"
+    axios: "npm:^1.15.1"
     axios-mock-adapter: "npm:^1.22.0"
     babel-loader: "npm:^9.1.2"
     babel-preset-react-app: "npm:^10.0.1"


### PR DESCRIPTION
## Summary

- Backport of #657 to v2.22 (OSSM 3.3).
- Upgrades axios from ^1.15.0 to ^1.15.1 (resolves to 1.15.2) to fix CVE-2026-42035

## Test plan

- [x] yarn install succeeds


Made with [Cursor](https://cursor.com)