### PR TITLE
[v1.73] Upgrade DOMPurify to 3.4.0+ to fix CVE-2026-41240

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -126,7 +126,7 @@
   },
   "resolutions": {
     "cross-spawn": "^7.0.5",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.0",
     "webpack": "^5.94.0"
   },
   "engines": {

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -6663,15 +6663,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "dompurify@npm:3.2.4"
+"dompurify@npm:^3.4.0":
+  version: 3.4.1
+  resolution: "dompurify@npm:3.4.1"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/6be56810fb7ad2776155c8fc2967af5056783c030094362c7d0cf1ad13f2129cf922d8eefab528a34bdebfb98e2f44b306a983ab93aefb9d6f24c18a3d027a05
+  checksum: 10c0/440a4246020cb54b82ef2cb66381e4d310a0c470f9994655e61b6122811f0eaa00a2f9665d2bed30ca3f58932ba7bb0d5e26fdfce61c8daf35d21a3f5a799e48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades DOMPurify from ^3.2.4 to ^3.4.0 (resolves to 3.4.1) to fix CVE-2026-41240
- DOMPurify prior to 3.4.0 is vulnerable to XSS via inconsistent tag sanitization when function-based ADD_TAGS predicates bypass FORBID_TAGS

## Test plan

- [x] yarn install succeeds


Made with [Cursor](https://cursor.com)