### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -53,7 +53,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -16,9 +16,13 @@ on:
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       branches: ${{ env.branches }}
@@ -45,6 +49,8 @@ jobs:
 
   bump_version:
     needs: [initialize]
+    permissions:
+      contents: write  # needs to push commits and tags
     runs-on: ubuntu-latest
     strategy:
       # Allow other branches to continue even if one of the branches failed

--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -9,9 +9,13 @@ on:
         default: v1.73,v2.4,v2.11
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       branches: ${{ env.branches }}
@@ -38,6 +42,8 @@ jobs:
 
   copy_kiali:
     needs: [initialize]
+    permissions:
+      contents: write  # needs to push commits to branches
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -44,7 +44,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{matrix.branch}}
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,9 +17,13 @@ on:
         default: quay.io/kiali/ossmconsole
         required: true
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       plugin_quay_tag: ${{ env.plugin_quay_tag }}
@@ -48,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'schedule' && github.repository == 'kiali/openshift-servicemesh-plugin') || github.event_name != 'schedule' }}
     needs: [initialize]
+    permissions:
+      contents: read
     env:
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
     steps:
@@ -64,8 +70,12 @@ jobs:
     - name: Print disk space after
       run: df -h
 
-    - name: Build and push plugin image
-      run: |
-        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+    - name: Login to Quay.io
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
 
-        make build-push-plugin-multi-arch
+    - name: Build and push plugin image
+      run: make build-push-plugin-multi-arch

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -52,7 +52,7 @@ jobs:
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 

--- a/.github/workflows/ossmc-ci.yaml
+++ b/.github/workflows/ossmc-ci.yaml
@@ -10,6 +10,8 @@ on:
     - '**/*.md'
     - '**/*.adoc'
 
+permissions: read-all
+
 jobs:
   lint_and_test:
     name: Lint and test

--- a/.github/workflows/ossmc-ci.yaml
+++ b/.github/workflows/ossmc-ci.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
     - name: Enable Corepack
       run: corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
       with:
         node-version: '24'
         cache: 'yarn'
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
     - name: Build image
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       kiali_src_code_version: ${{ env.kiali_src_code_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -218,7 +218,7 @@ jobs:
       RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,13 @@ on:
         type: string
         required: false
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       target_branch: ${{ github.ref_name }}
@@ -90,7 +94,7 @@ jobs:
     - name: Determine release type
       id: release_type
       run: |
-        if [ -z ${{ github.event.inputs.release_type }} ];
+        if [ -z "${{ github.event.inputs.release_type }}" ];
         then
           DO_RELEASE=$(python minor.py)
           if [[ $DO_RELEASE == "True" ]]
@@ -208,6 +212,9 @@ jobs:
     if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/openshift-servicemesh-plugin') || github.event_name != 'schedule') }}
     runs-on: ubuntu-latest
     needs: [initialize]
+    permissions:
+      contents: write  # needs to push tags and branches
+      pull-requests: write  # needs to create PRs
     env:
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
@@ -243,11 +250,15 @@ jobs:
       run: |
         hack/update-version-string.sh "$RELEASE_VERSION"
 
-    - name: Build and push images
-      run: |
-        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+    - name: Login to Quay.io
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER }}
+        password: ${{ secrets.QUAY_PASSWORD }}
 
-        make build-push-plugin-multi-arch
+    - name: Build and push images
+      run: make build-push-plugin-multi-arch
 
     - name: Create tag
       run: |

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -9,9 +9,13 @@ on:
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 
+permissions: read-all
+
 jobs:
   initialize:
     name: Initialize
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       branches: ${{ env.branches }}
@@ -38,6 +42,8 @@ jobs:
 
   release_tag:
     needs: [initialize]
+    permissions:
+      contents: write  # needs to push and delete tags
     runs-on: ubuntu-latest
     strategy:
       # Allow other branches to continue even if one of the branches failed

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -46,7 +46,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -41,6 +41,8 @@ on:
         required: true
 
 
+permissions: read-all
+
 jobs:
   build_and_push_cypress_tests:
     name: Generate and push ossmc cypress test docker images

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -56,11 +56,11 @@ jobs:
         echo "Quay organization": ${{ inputs.quay_org }}
         echo "Images tag": ${{ inputs.images_tag }}
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}


### PR DESCRIPTION
This PR hardens the GitHub Actions workflows against several known vulnerability classes.

**Supply chain risk (unpinned actions):** All third-party actions were using floating version tags (e.g. `@v3`, `@v4`, `@v5`). These are mutable references — a compromised action maintainer can silently retag them to malicious code that executes in CI with access to repository secrets. All action references have been pinned to their full immutable commit SHA, with the version tag retained as a comment.

**Credential exposure via `docker login -p`:** The nightly and release workflows were passing Quay credentials directly as a `-p` CLI argument to `docker login`, exposing the password in the process list (`ps aux`). Both have been replaced with `docker/login-action`, which passes credentials securely. The CI and test-images workflows were already using `docker/login-action` correctly.

**Missing `permissions:` blocks:** None of the workflows declared explicit token permissions, meaning they inherited the repository default (typically broad write access). All workflows now declare `permissions: read-all` at the top level, with `contents: write` and/or `pull-requests: write` granted only to the specific jobs that actually need them (release, tag creation, version bumping, branch pushes).

**Unquoted shell variable expansion:** The release workflow had an unquoted `[ -z ${{ }} ]` expression that could behave unpredictably with empty inputs. This has been quoted.

Generated-by: Claude