### PR TITLE
[v2.22] Enable PQC ML-KEM key exchange and enforce TLS 1.3 for OSSMC nginx

### DIFF
--- a/plugin/manifest.yaml
+++ b/plugin/manifest.yaml
@@ -95,6 +95,8 @@ data:
         listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
+        ssl_protocols       TLSv1.3;
+        ssl_conf_command Groups x25519mlkem768:x25519:prime256v1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 

--- a/plugin/manifest.yaml
+++ b/plugin/manifest.yaml
@@ -95,8 +95,10 @@ data:
         listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
+        # Only TLS client is the OCP Console backend (Go 1.24+), so TLS 1.2 is unnecessary
         ssl_protocols       TLSv1.3;
-        ssl_conf_command Groups x25519mlkem768:x25519:prime256v1:secp384r1;
+        # PQC hybrid groups for ML-KEM; requires OpenSSL >= 3.5
+        ssl_ecdh_curve      x25519mlkem768:SecP256r1MLKEM768:x25519:prime256v1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 


### PR DESCRIPTION
Backport of https://github.com/kiali/openshift-servicemesh-plugin/pull/690 to v2.22.

## Summary

- Add `ssl_protocols TLSv1.3` and `ssl_conf_command Groups x25519mlkem768:x25519:prime256v1:secp384r1` to the OSSMC nginx config in `manifest.yaml`
- Enables post-quantum hybrid key exchange (X25519MLKEM768) and restricts to TLS 1.3 only

## Context

The [tls-scanner](https://github.com/openshift/tls-scanner) flagged OSSMC as not supporting PQC ML-KEM. The root cause is that the nginx config had no `ssl_protocols` or key exchange group directives, falling back to defaults that don't include ML-KEM groups.

Since the only TLS client is the OpenShift Console backend, which fully supports TLS 1.3, there is no backward compatibility concern with dropping TLS 1.2.

## Test plan

- [ ] Verify on OpenShift cluster: `openssl s_client` confirms `Negotiated TLS1.3 group: X25519MLKEM768`
- [ ] Re-run tls-scanner against OSSMC to confirm PQC check passes


Made with [Cursor](https://cursor.com)