### PR TITLE
Align GitHub Actions to latest versions with commit SHAs

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -59,7 +59,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/copy-kiali-frontend.yml
+++ b/.github/workflows/copy-kiali-frontend.yml
@@ -43,14 +43,14 @@ jobs:
   copy_kiali:
     needs: [initialize]
     permissions:
-      contents: write  # needs to push commits to branches
+      contents: write # needs to push commits to branches
     runs-on: ubuntu-latest
     strategy:
       matrix:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{matrix.branch}}
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,7 +58,7 @@ jobs:
       PLUGIN_QUAY_TAG: ${{ needs.initialize.outputs.plugin_quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -71,7 +71,7 @@ jobs:
       run: df -h
 
     - name: Login to Quay.io
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/ossmc-ci.yaml
+++ b/.github/workflows/ossmc-ci.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Enable Corepack
       run: corepack enable
 
     - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '24'
         cache: 'yarn'
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Build image
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
       kiali_src_code_version: ${{ env.kiali_src_code_version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -213,8 +213,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [initialize]
     permissions:
-      contents: write  # needs to push tags and branches
-      pull-requests: write  # needs to create PRs
+      contents: write # needs to push tags and branches
+      pull-requests: write # needs to create PRs
     env:
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
@@ -225,7 +225,7 @@ jobs:
       RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -251,7 +251,7 @@ jobs:
         hack/update-version-string.sh "$RELEASE_VERSION"
 
     - name: Login to Quay.io
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -52,7 +52,7 @@ jobs:
         branch: ${{fromJson(needs.initialize.outputs.branches)}}
     steps:
     - name: Checkout branch
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{matrix.branch}}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/test-images-creator.yml
+++ b/.github/workflows/test-images-creator.yml
@@ -58,11 +58,11 @@ jobs:
         echo "Quay organization": ${{ inputs.quay_org }}
         echo "Images tag": ${{ inputs.images_tag }}
     - name: Checkout code
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ inputs.release_branch }}
     - name: Login to Quay.io
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER }}


### PR DESCRIPTION
### Describe the change

Align all GitHub Actions across workflows to their latest versions, pinned to immutable commit SHAs. This resolves Node.js 20 deprecation warnings and improves supply chain security.

- `actions/checkout`: v4/v5 -> v6.0.2 (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `docker/login-action`: v3 -> v4.2.0 (`650006c6eb7dba73a995cc03b0b2d7f5ca915bee`)
- `actions/setup-node`: add precise v6.4.0 version comment (`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`)

### Steps to test the PR

- Verify CI workflow (`ossmc-ci.yaml`) passes
- Run a nightly or release workflow to confirm docker login still works with v4.2.0

Made with [Cursor](https://cursor.com)