### PR TITLE
Remove ssl_ecdh_curve to support FIPS-enabled clusters

### DIFF
--- a/plugin/manifest.yaml
+++ b/plugin/manifest.yaml
@@ -95,10 +95,8 @@ data:
         listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
-        # Only TLS client is the OCP Console backend (Go 1.24+), so TLS 1.2 is unnecessary
+        # Only TLS client is the OCP Console backend, which supports TLS 1.3
         ssl_protocols       TLSv1.3;
-        # PQC hybrid groups for ML-KEM; requires OpenSSL >= 3.5
-        ssl_ecdh_curve      x25519mlkem768:SecP256r1MLKEM768:x25519:prime256v1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 


### PR DESCRIPTION
## Summary
- Removes the `ssl_ecdh_curve` nginx directive that hardcodes non-FIPS-approved curves (`x25519mlkem768`, `SecP256r1MLKEM768`, `x25519`)
- On FIPS-enabled clusters (e.g. ARO), OpenSSL rejects the entire curve list causing nginx to crash: `SSL_CTX_set1_curves_list(...) failed`
- Without the directive, OpenSSL selects curves based on its runtime config: FIPS-approved curves in FIPS mode, PQC hybrid groups by default on OpenSSL 3.5+

## Test plan
- [ ] Deploy OSSMC on a FIPS-enabled cluster (e.g. ARO) and verify nginx starts successfully
- [ ] Deploy OSSMC on a non-FIPS cluster and verify TLS 1.3 still works


Made with [Cursor](https://cursor.com)