### PR TITLE
Fix waypoint table headers missing due to uninitialized i18next singleton

### DIFF
--- a/plugin/src/openshift/i18n.ts
+++ b/plugin/src/openshift/i18n.ts
@@ -1,15 +1,18 @@
 import i18next, { i18n as I18nInstance } from 'i18next';
 import { getI18n } from 'react-i18next';
 
-const fallbackI18n = i18next.createInstance();
-void fallbackI18n.init({ fallbackLng: 'en' });
+// Initialize the default i18next singleton so that vendored Kiali code
+// importing `t` directly from 'i18next' gets key fallbacks instead of undefined.
+if (!i18next.isInitialized) {
+  void i18next.init({ fallbackLng: 'en' });
+}
 
-const resolveI18n = (): I18nInstance => getI18n() ?? fallbackI18n;
+const resolveI18n = (): I18nInstance => getI18n() ?? i18next;
 
 // Kiali code imports `i18n` directly, but OSSMC relies on the react-i18next instance
 // provided by the OpenShift console. Delegating here keeps helper-based translations
 // in sync with the active UI language instead of falling back to English.
-export const i18n = new Proxy(fallbackI18n as I18nInstance, {
+export const i18n = new Proxy(i18next as I18nInstance, {
   get: (_target, prop) => {
     const activeI18n = resolveI18n() as unknown as object;
     const value = Reflect.get(activeI18n, prop);

--- a/plugin/src/openshift/utils/MenuTitles.ts
+++ b/plugin/src/openshift/utils/MenuTitles.ts
@@ -1,10 +1,10 @@
-import i18next from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 // Dummy OSSMC menu titles to be detected by i18next parser tool and added to i18n locale file
-export const overview = i18next.t('Overview');
-export const graph = i18next.t('Traffic Graph');
-export const mesh = i18next.t('Mesh');
-export const namespaces = i18next.t('Namespaces');
-export const appList = i18next.t('Applications');
-export const istioConfig = i18next.t('Istio Config');
-export const serviceMesh = i18next.t('Service Mesh');
+export const overview = t('Overview');
+export const graph = t('Traffic Graph');
+export const mesh = t('Mesh');
+export const namespaces = t('Namespaces');
+export const appList = t('Applications');
+export const istioConfig = t('Istio Config');
+export const serviceMesh = t('Service Mesh');


### PR DESCRIPTION
## Summary

- Initialize the default `i18next` singleton in OSSMC so that vendored Kiali code importing `t` directly from `'i18next'` returns key fallbacks instead of `undefined`
- Remove the redundant `fallbackI18n` instance, reusing the now-initialized default singleton
- Switch `MenuTitles.ts` to use `utils/I18nUtils` for consistency

## Root Cause

Vendored components like `WaypointWorkloadsTable` and `WaypointLabel` import `t` directly from `'i18next'` instead of `'utils/I18nUtils'`. In OSSMC the default `i18next` singleton was never initialized -- only a separate `createInstance()` copy was. Calling `t()` on an uninitialized instance returns `undefined`, causing column headers and translated strings to disappear.

This also serves as a safety net: if a future Kiali frontend sync reintroduces direct `'i18next'` imports, OSSMC won't silently break.

The upstream fix (changing the imports in vendored code) will be submitted separately to [kiali/kiali](https://github.com/kiali/kiali).

Fixes #699

## Files Changed

- `plugin/src/openshift/i18n.ts` -- init default `i18next` singleton; remove redundant `fallbackI18n`
- `plugin/src/openshift/utils/MenuTitles.ts` -- use `utils/I18nUtils` instead of direct `i18next` import

## Test Plan

- [ ] Deploy OSSMC and navigate to a waypoint workload's Service Mesh > Waypoint tab
- [ ] Verify column headers (Name, Namespace, Labeled by) are visible
- [ ] Verify "List of enrolled services/workloads" title is fully displayed
- [ ] Verify other i18n translations still work (overview, graph, mesh pages)

Made with [Cursor](https://cursor.com)