### PR TITLE
Upgrade ip-address for CVE-2026-42338

### DIFF
--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -11903,9 +11903,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10c0/0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades transitive `ip-address` dependency from 10.1.0 to 10.2.0 in `plugin/yarn.lock`
- Addresses CVE-2026-42338 (XSS via improper HTML escaping in `Address6.group()`, `Address6.link()`, and `AddressError.parseMessage`; fixed in 10.1.1)
- Companion to kiali/kiali#9843

## Test plan

- [x] `yarn install --no-immutable` succeeded on `main`

Made with [Cursor](https://cursor.com)