### PR TITLE
upgrade axios to 1.17.0

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -46,7 +46,7 @@
     "@patternfly/react-icons": "^6.4.0",
     "@patternfly/react-table": "^6.4.0",
     "@patternfly/react-topology": "^6.4.0",
-    "axios": "^1.15.1",
+    "axios": "^1.17.0",
     "bootstrap-slider-without-jquery": "10.0.0",
     "deep-freeze": "0.0.1",
     "eventemitter3": "4.0.7",

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -6205,6 +6205,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: "npm:4"
+  checksum: 10c0/dc4f757e40b5f3e3d674bc9beb4f1048f4ee83af189bae39be99f57bf1f48dde166a8b0a5342a84b5944ee8e6ed1e5a9d801858f4ad44764e84957122fe46261
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
@@ -6684,14 +6693,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.15.1":
-  version: 1.15.2
-  resolution: "axios@npm:1.15.2"
+"axios@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "axios@npm:1.17.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
+  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
   languageName: node
   linkType: hard
 
@@ -10473,7 +10483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
@@ -11628,6 +11638,16 @@ __metadata:
   version: 1.0.0
   resolution: "https-browserify@npm:1.0.0"
   checksum: 10c0/e17b6943bc24ea9b9a7da5714645d808670af75a425f29baffc3284962626efdc1eb3aa9bbffaa6e64028a6ad98af5b09fabcb454a8f918fb686abfdc9e9b8ae
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10c0/6dd639f03434003577c62b27cafdb864784ef19b2de430d8ae2a1d45e31c4fd60719e5637b44db1a88a046934307da7089e03d6089ec3ddacc1189d8de8897d1
   languageName: node
   linkType: hard
 
@@ -15652,7 +15672,7 @@ __metadata:
     "@types/webpack-dev-server": "npm:^4.5.0"
     "@typescript-eslint/eslint-plugin": "npm:^7.0.0"
     "@typescript-eslint/parser": "npm:^7.0.0"
-    axios: "npm:^1.15.1"
+    axios: "npm:^1.17.0"
     axios-mock-adapter: "npm:^1.22.0"
     babel-loader: "npm:^9.1.2"
     babel-preset-react-app: "npm:^10.0.1"


### PR DESCRIPTION
## Summary

Upgrade axios from 1.15.1 to 1.17.0 to fix multiple CVEs:

- CVE-2025-27152
- CVE-2025-30204
- CVE-2025-34583
- CVE-2026-25008
- CVE-2026-31498
- CVE-2026-40498
- CVE-2026-44495

All CVEs require axios >= 1.16.0. The latest 1.x release (1.17.0) is used to cover all fixes.

## Changes

- `plugin/package.json`: bumped `axios` from `^1.15.1` to `^1.17.0`
- `plugin/yarn.lock`: resolved to `axios@1.17.0`

Made with [Cursor](https://cursor.com)