### PR TITLE
Register cy.task('log') handler in Cypress config

### DIFF
--- a/plugin/cypress.config.ts
+++ b/plugin/cypress.config.ts
@@ -30,6 +30,13 @@ export default defineConfig({
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
       await addCucumberPreprocessorPlugin(on, config);
 
+      on('task', {
+        log(message: string) {
+          console.log(message);
+          return null;
+        }
+      });
+
       on(
         'file:preprocessor',
         createBundler({


### PR DESCRIPTION
## Summary

- Register the missing `log` task in `setupNodeEvents` to fix waypoint test failures

## Problem

The vendored `kiali-config.ts` (synced from kiali/kiali) uses `cy.task('log', ...)` for debug logging during Kiali deployment discovery and feature enablement. This task was registered in Kiali's standalone Cypress config but was never added to OSSMC's `cypress.config.ts`.

This causes all waypoint tests to fail at setup with:

```
cy.task('log') failed with the following error:
The task 'log' was not handled in the setupNodeEvents method.
```

## Fix

Register a simple `log` task that prints to the Node.js console and returns `null`.

## Test plan

- [ ] Run waypoint Cypress tests (`@waypoint` tag) — setup scenario should pass
- [ ] Verify no regressions in other test suites


Made with [Cursor](https://cursor.com)