### PR TITLE
Use KIALI_BOT_TOKEN for release workflow push to protected branches

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -16,8 +16,6 @@ on:
         default: v1.73,v2.4,v2.11,v2.17,v2.22
         type: string
 
-permissions: read-all
-
 jobs:
   initialize:
     name: Initialize
@@ -62,6 +60,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{matrix.branch}}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
         # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -228,6 +228,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
 
     # /opt/hostedtoolcache directory is large and has tools we do not need so delete it to free up space
     - name: Print disk space before

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -93,3 +93,4 @@ jobs:
     uses: ./.github/workflows/bump-release-version.yml
     with:
       tag_branches: ${{ inputs.tag_branches }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Follow-up to #724. The previous fix resolved the permissions: read-all conflict, but the workflow still fails because GITHUB_TOKEN cannot push to protected release branches.
- Use KIALI_BOT_TOKEN in the checkout step of bump-release-version.yml so git push authenticates as kiali-bot, which has bypass permissions on protected branches.
- Pass secrets to the reusable workflow via secrets: inherit in tag-release-creator.yml.

Same fix as https://github.com/kiali/kiali/pull/9899.

## Test plan
- [ ] Trigger the Release Tag Creator workflow and verify bump_version can push to a protected branch