### PR TITLE
Upgrade transitive ws dependency to fix CVE-2026-48779

### DIFF
--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -20877,8 +20877,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.18.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -20887,7 +20887,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/4741d9b9bc3f9c791880882414f96e36b8b254e34d4b503279d6400d9a4b87a033834856dbdd94ee4b637944df17ea8afc4bce0ff4a1560d2166be8855da5b04
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Regenerate `plugin/yarn.lock` to pick up `ws` 8.21.0
- Fixes CVE-2026-48779: memory exhaustion denial-of-service via small WebSocket fragments
- `ws` is a transitive dependency; the `^8.18.0` semver range already allows the fix version

## Test plan

- [x] `yarn install` succeeds
- [ ] CI passes

Made with [Cursor](https://cursor.com)