### PR TITLE
[v1.73] Upgrade transitive ws dependency to fix CVE-2026-48779

### DIFF
--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -14856,8 +14856,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.16.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -14866,7 +14866,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Backport of #726 to `v1.73`
- Regenerate `plugin/yarn.lock` to pick up `ws` 8.21.0
- Fixes CVE-2026-48779: memory exhaustion denial-of-service via small WebSocket fragments

## Test plan

- [x] `yarn install` succeeds
- [ ] CI passes

Made with [Cursor](https://cursor.com)