### PR TITLE
Update js-cookie to fix CVE-2026-46625

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -149,6 +149,7 @@
   },
   "resolutions": {
     "immutable": "^4.3.8",
+    "js-cookie": "^3.0.8",
     "react-markdown": "^8.0.7",
     "unist-util-visit-parents": "^5.1.3",
     "webpack": "^5.104.1"

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -13796,10 +13796,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.1":
-  version: 3.0.1
-  resolution: "js-cookie@npm:3.0.1"
-  checksum: 10c0/a7dab91286c49610fb198bcc0d78fbafe9be869cf3cea6f7eaea515abdfdc9d347982fe22316e34666b479a0701119482d46faa3a350a3a3404eb954405edf72
+"js-cookie@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 10c0/421912a4a55535bda32b3059835864e1182c3af5b4516df00a060edc1fa5a53d38bb8d5a91d5d305e396206f4fd11e829f17850aa5aa8164118c04d8ebf1ff5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add yarn resolution for js-cookie ^3.0.8 to fix CVE-2026-46625 (Cookie attribute manipulation via prototype pollution).

The upstream `@segment/analytics-next` (via `@patternfly/chatbot`) pins `js-cookie` to exactly `3.0.1`, which is vulnerable. A yarn resolution is required to force the patched version since no upstream update is available.

**Dependency chain**: `@patternfly/chatbot` → `@segment/analytics-next` → `js-cookie@3.0.1` (pinned)

**Fix**: `js-cookie` 3.0.1 → 3.0.8

Made with [Cursor](https://cursor.com)