### PR TITLE
Fix cy.visit override doubling ossmconsole path prefix

### DIFF
--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -224,6 +224,11 @@ function istioDetailToRef(detailPath: string): string {
 }
 
 Cypress.Commands.overwrite('visit', (originalFn, visitUrl) => {
+  const path = new URL(visitUrl.url, Cypress.config('baseUrl')).pathname;
+  if (path.startsWith('/ossmconsole/') || path.startsWith('/k8s/')) {
+    return originalFn(visitUrl);
+  }
+
   const webParamsIndex = visitUrl.url.indexOf('?');
   const webParams = webParamsIndex > -1 ? visitUrl.url.substring(webParamsIndex) : '';
 


### PR DESCRIPTION
## Summary
- Fix the Cypress `visit` command override that incorrectly transforms URLs already in OSSMC format, producing paths like `/ossmossmconsole/` instead of `/ossmconsole/`.
- The issue occurs when steps like "user reorders columns in the modal" get the current browser URL (already `/ossmconsole/...`) and revisit it — the `default` case's `.replace('console/', 'ossmconsole/')` matches the `console/` substring inside `ossmconsole/`.
- Added an early return that detects paths already starting with `/ossmconsole/` or `/k8s/` and passes them through untransformed.

## Test plan
- [ ] Run column management E2E tests that exercise the "user reorders columns in the modal" step
- [ ] Verify the URL remains `/ossmconsole/applications?...` (not `/ossmossmconsole/...`)
- [ ] Confirm existing Cypress tests still pass (the early return only triggers for already-transformed paths)


Made with [Cursor](https://cursor.com)