### PR TITLE
[CI] Update release schedule to Mondays and check Kiali release availability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   schedule:
-  # Every Tuesday at 01:00 (UTC) which is the day after the server release is done. This action takes several hours to complete.
-  - cron: "00 1 * * TUE"
+  # Every Monday at 01:00 (UTC) which is the day after the server release is done. This action takes several hours to complete.
+  - cron: "00 1 * * MON"
   workflow_dispatch:
     inputs:
       release_type:
@@ -242,6 +242,17 @@ jobs:
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
+
+    - name: Check Kiali release is available
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "Checking if Kiali release $RELEASE_VERSION exists..."
+        if ! gh release view "$RELEASE_VERSION" --repo kiali/kiali > /dev/null 2>&1; then
+          echo "::error::Kiali release $RELEASE_VERSION not found in kiali/kiali. The Kiali server release must complete before the OSSMC release can proceed."
+          exit 1
+        fi
+        echo "Kiali release $RELEASE_VERSION found. Proceeding with OSSMC release."
 
     - name: Copy Kiali source code
       run: |


### PR DESCRIPTION
## Summary
- Update release cron schedule from Tuesdays to Mondays to align with the Kiali server release moving to Sundays (kiali/kiali#9932)
- Add a pre-release check that verifies the corresponding Kiali release exists before proceeding, preventing OSSMC from releasing with stale source code

## Test plan
- [ ] Verify cron expression `"00 1 * * MON"` triggers on Mondays at 01:00 UTC
- [ ] Verify `gh release view` correctly detects existing/missing releases in kiali/kiali
- [ ] Confirm manual `workflow_dispatch` also runs the Kiali release check

Made with [Cursor](https://cursor.com)