### PR TITLE
[v2.27] Fix cy.visit override doubling ossmconsole path prefix

### DIFF
--- a/plugin/cypress/support/commands.ts
+++ b/plugin/cypress/support/commands.ts
@@ -198,6 +198,11 @@ const istioDetailToRef = (detailPath: string): string => {
 };
 
 Cypress.Commands.overwrite('visit', (originalFn, visitUrl) => {
+  const path = new URL(visitUrl.url, Cypress.config('baseUrl')).pathname;
+  if (path.startsWith('/ossmconsole/') || path.startsWith('/k8s/')) {
+    return originalFn(visitUrl);
+  }
+
   const webParamsIndex = visitUrl.url.indexOf('?');
   const webParams = webParamsIndex > -1 ? visitUrl.url.substring(webParamsIndex) : '';
 


### PR DESCRIPTION
## Summary

Backport of #743 to v2.27.

* Fix the Cypress `visit` command override that incorrectly transforms URLs already in OSSMC format, producing paths like `/ossmossmconsole/` instead of `/ossmconsole/`.
* Added an early return that detects paths already starting with `/ossmconsole/` or `/k8s/` and passes them through untransformed.

## Test plan

- [ ] Run column management E2E tests that exercise the "user reorders columns in the modal" step
- [ ] Verify the URL remains `/ossmconsole/applications?...` (not `/ossmossmconsole/...`)
- [ ] Confirm existing Cypress tests still pass


Made with [Cursor](https://cursor.com)