### PR TITLE
[v2.27] Fix cypress/support/ import paths after kiali frontend copy

### DIFF
--- a/hack/copy-frontend-src-to-ossmc.sh
+++ b/hack/copy-frontend-src-to-ossmc.sh
@@ -204,6 +204,12 @@ cp -R ${ABS_SOURCE_TESTS_DIR}/* ${ABS_DEST_TESTS_DIR}
 # OSSMC has its own hooks.ts file, so we remove the Kiali one
 rm ${ABS_DEST_TESTS_DIR}/common/hooks.ts
 
+# Vendored tests sit one directory level deeper than in the kiali repo
+# (integration/kiali/common/ vs integration/common/), so relative imports
+# that reach into cypress/support/ need an extra "../".
+find ${ABS_DEST_TESTS_DIR} -name '*.ts' -exec \
+  sed -i "s|../support/|../../support/|g" {} +
+
 cat > ${ABS_DEST_DIR}/README.md <<EOM
 **WARNING**: The code in this directory comes from the kiali/kiali repository and should never be modified here.
 

--- a/plugin/cypress/integration/kiali/common/graph.ts
+++ b/plugin/cypress/integration/kiali/common/graph.ts
@@ -5,6 +5,7 @@
 
 import { Then } from '@badeball/cypress-cucumber-preprocessor';
 import { Controller, Edge, Node, isNode, isEdge, GraphElement, Visualization } from '@patternfly/react-topology';
+import { buildNodeTree, findComponentsInTree, getReactFiber } from '../../../support/react-utils';
 
 Then('user does not see a minigraph', () => {
   cy.get('#MiniGraphCard').find('h5').contains('Empty Graph');
@@ -46,19 +47,28 @@ Then('nodes in the {string} cluster should contain the cluster name in their lin
 Then(
   'user clicks on the {string} workload in the {string} namespace in the {string} cluster',
   (workload: string, namespace: string, cluster: string) => {
-    cy.waitForReact();
-    cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-      .should('have.length', '1')
-      .then($graph => {
-        const { state } = $graph[0];
+    let nodeId: string;
 
+    cy.waitForReact();
+    cy.window({ log: false })
+      .should((win: Window) => {
+        const rootFiber = freshFiber(win);
+        assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+        const tree = buildNodeTree(rootFiber);
+        const results = findComponentsInTree(tree, 'GraphPageComponent', {
+          state: { graphData: { isLoading: false }, isReady: true }
+        });
+        assert.equal(results.length, 1, 'GraphPageComponent should be loaded and ready');
+
+        const { state } = results[0];
         const controller = state.graphRefs.getController() as Visualization;
         assert.isTrue(controller.hasGraph());
         const { nodes } = elems(controller);
 
+        // Workloads are apps in the versioned app graph
         const workloadNode = nodes.filter(
           node =>
-            // Apparently workloads are apps for the versioned app graph.
             node.getData().nodeType === 'app' &&
             node.getData().isBox === undefined &&
             node.getData().workload === workload &&
@@ -67,15 +77,12 @@ Then(
         );
 
         expect(workloadNode.length).to.equal(1);
-        cy.get(`[data-id=${workloadNode[0]?.getId()}]`)
-          .click()
-          .then(() => {
-            // Wait for the side panel to change.
-            // Note we can't use summary-graph-panel since that
-            // element will get unmounted and disappear when
-            // the context changes but the graph-side-panel does not.
-            cy.get('#graph-side-panel').contains(workload);
-          });
+        nodeId = workloadNode[0]?.getId();
+      })
+      .then(() => {
+        cy.get(`[data-id=${nodeId}]`).click();
+        // graph-side-panel persists across context changes unlike summary-graph-panel
+        cy.get('#graph-side-panel').contains(workload);
       });
   }
 );
@@ -120,35 +127,52 @@ export const elems = (c: Controller): { edges: Edge[]; nodes: Node[] } => {
 };
 
 /**
- * Retryable assertion wrapper for the full-page graph. Uses `.should()` instead
- * of `.then()` so Cypress automatically retries the callback when an assertion
- * fails, eliminating race conditions with graph data loading.
+ * Read the React fiber root fresh from the DOM so that `.should()` retries
+ * always see the latest committed React state instead of a stale cached
+ * reference from `waitForReact()`.
  */
-export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
-  cy.waitForReact();
-  cy.getReact('GraphPageComponent', { state: { graphData: { isLoading: false }, isReady: true } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
-    });
+const freshFiber = (win: Window): any => {
+  const rootSelector = Cypress.env('rootSelector') || 'body';
+  const rootEl = win.document.querySelector(rootSelector);
+  return rootEl ? getReactFiber(rootEl as Element) : null;
 };
 
 /**
- * Retryable assertion wrapper for the mini graph card.
+ * Retryable assertion wrapper that re-reads the React fiber root from the
+ * DOM on every `.should()` retry, ensuring Cypress always sees the latest
+ * committed React state.
+ *
+ * The previous approach used `cy.getReact()` which returned a static
+ * `cy.wrap()` snapshot — `.should()` retried the assertion against that
+ * stale snapshot, causing false negatives after graph refetches.
  */
-export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+const assertReady = (
+  componentName: string,
+  stateFilter: Record<string, any>,
+  fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void
+): void => {
   cy.waitForReact();
-  cy.getReact('MiniGraphCardComponent', { state: { isReady: true, isLoading: false } })
-    .should('have.length', '1')
-    .should(($graph: any) => {
-      const { state } = $graph[0];
-      const controller = state.graphRefs.getController() as Visualization;
-      assert.isTrue(controller.hasGraph());
-      fn(elems(controller), state);
-    });
+  cy.window({ log: false }).should((win: Window) => {
+    const rootFiber = freshFiber(win);
+    assert.isNotNull(rootFiber, 'React fiber root must exist');
+
+    const tree = buildNodeTree(rootFiber);
+    const results = findComponentsInTree(tree, componentName, { state: stateFilter });
+    assert.equal(results.length, 1, `${componentName} should be loaded and ready`);
+
+    const { state } = results[0];
+    const controller = state.graphRefs.getController() as Visualization;
+    assert.isTrue(controller.hasGraph());
+    fn(elems(controller), state);
+  });
+};
+
+export const assertGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+  assertReady('GraphPageComponent', { graphData: { isLoading: false }, isReady: true }, fn);
+};
+
+export const assertMiniGraphReady = (fn: (elements: { edges: Edge[]; nodes: Node[] }, state: any) => void): void => {
+  assertReady('MiniGraphCardComponent', { isReady: true, isLoading: false }, fn);
 };
 
 export type SelectOp =

--- a/plugin/cypress/integration/kiali/common/graph_display.ts
+++ b/plugin/cypress/integration/kiali/common/graph_display.ts
@@ -3,6 +3,8 @@ import { ensureKialiFinishedLoading } from './transition';
 import { assertGraphReady, select, selectAnd, selectOr } from './graph';
 import { EdgeAttr, NodeAttr } from 'types/Graph';
 
+const CLIENT_SIDE_ONLY_OPTIONS = ['filterTrafficAnimation', 'filterSidecars', 'rank'];
+
 When('user graphs {string} namespaces', (namespaces: string) => {
   // Forcing "Pause" to not cause unhandled promises from the browser when cypress is testing
   cy.intercept(`**/api/namespaces/graph*`).as('graphNamespaces');
@@ -23,7 +25,7 @@ When('user graphs {string} namespaces', (namespaces: string) => {
 });
 
 When('user {string} display menu', (_action: string) => {
-  cy.get('button#display-settings').click();
+  cy.get('button#display-settings').should('not.be.disabled').click();
 });
 
 When('user enables {string} {string} edge labels', (radio: string, edgeLabel: string) => {
@@ -89,12 +91,14 @@ When('user {string} {string} option', (action: string, option: string) => {
     if (option === 'rank') {
       cy.get(`input#inboundEdges`).check();
     }
-    if (option === 'filterWaypoints') {
-      cy.wait('@graphNamespaces');
-    }
   } else {
     cy.get('div#graph-display-menu').find(`input#${option}`).uncheck();
   }
+
+  if (!CLIENT_SIDE_ONLY_OPTIONS.includes(option)) {
+    cy.wait('@graphNamespaces');
+  }
+
   ensureKialiFinishedLoading();
 });
 

--- a/plugin/cypress/integration/kiali/common/graph_toolbar.ts
+++ b/plugin/cypress/integration/kiali/common/graph_toolbar.ts
@@ -20,16 +20,17 @@ When('user closes graph tour', () => {
 });
 
 When('user {string} traffic menu', (action: string) => {
-  cy.get('button#graph-traffic-dropdown').then($button => {
-    const currentState = $button.attr('aria-expanded');
-    const isCurrentlyOpen = currentState === 'true';
-    const shouldBeOpen = action.includes('open');
+  cy.get('button#graph-traffic-dropdown')
+    .should('not.be.disabled')
+    .then($button => {
+      const currentState = $button.attr('aria-expanded');
+      const isCurrentlyOpen = currentState === 'true';
+      const shouldBeOpen = action.includes('open');
 
-    // Only click if the current state is different from the desired state
-    if (isCurrentlyOpen !== shouldBeOpen) {
-      cy.wrap($button).click();
-    }
-  });
+      if (isCurrentlyOpen !== shouldBeOpen) {
+        cy.wrap($button).click();
+      }
+    });
 });
 
 When('user {string} {string} traffic option', (action: string, option: string) => {

--- a/plugin/cypress/integration/kiali/common/istio_config_type_filters.ts
+++ b/plugin/cypress/integration/kiali/common/istio_config_type_filters.ts
@@ -44,6 +44,7 @@ Then('user can see the filter options', () => {
     'ServiceEntry',
     'Sidecar',
     'Telemetry',
+    'TrafficExtension',
     'VirtualService',
     'WasmPlugin',
     'WorkloadEntry',

--- a/plugin/cypress/integration/kiali/common/kiali-config.ts
+++ b/plugin/cypress/integration/kiali/common/kiali-config.ts
@@ -69,6 +69,10 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
       { failOnNonZeroExit: false }
     )
     .then(result => {
+      cy.task(
+        'log',
+        `[DISCOVER_KIALI] label query: code=${result.code}, stdout="${result.stdout.trim()}", stderr="${result.stderr}"`
+      );
       const lines = result.stdout
         .trim()
         .split('\n')
@@ -76,6 +80,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
         .filter(Boolean);
 
       if (!lines.length || lines[0] === '') {
+        cy.task('log', '[DISCOVER_KIALI] Label query returned no results — trying fallback');
         // Fallback: look for a deployment named "kiali" in any namespace.
         return cy
           .exec(
@@ -94,6 +99,8 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
               .filter(l => l.includes('/kiali'))
               .filter(Boolean);
 
+            cy.task('log', `[DISCOVER_KIALI] Fallback matches: ${JSON.stringify(fallbackLines)}`);
+
             const preferredNamespaces = ['istio-system', 'kiali-operator', 'default'];
 
             let fallbackChosen: string | undefined;
@@ -111,6 +118,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
               );
             }
 
+            cy.task('log', `[DISCOVER_KIALI] Fallback chosen: ${fallbackChosen}`);
             const [namespace, deploymentName] = fallbackChosen.split('/');
             return resolveConfigMap(namespace, deploymentName);
           });
@@ -120,6 +128,7 @@ export const discoverKialiRuntimeInfo = (): Cypress.Chainable<KialiRuntimeInfo> 
       const parts = lines[0].split(/\s+/);
       const namespace = parts[0];
       const deploymentName = parts[1];
+      cy.task('log', `[DISCOVER_KIALI] Found via label: namespace=${namespace}, deployment=${deploymentName}`);
       return resolveConfigMap(namespace, deploymentName);
     });
 };
@@ -227,9 +236,13 @@ export const enableKialiFeature = (featureConfig: KialiFeatureConfig, value = tr
  * (operator vs Helm) don't have to re-discover deployment info.
  */
 export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
+  cy.task('log', `[ENABLE_CACHING] enableKialiCaching called, existingInfo=${existingInfo ? 'provided' : 'null'}`);
+
   const doPatch = (info: KialiRuntimeInfo): void => {
     const doRestart = (): void => {
+      cy.task('log', `[ENABLE_CACHING] Restarting Kiali: deployment/${info.deploymentName} -n ${info.namespace}`);
       restartKiali(info.deploymentName, info.namespace);
+      cy.task('log', '[ENABLE_CACHING] Kiali restart complete');
     };
 
     cy.exec(
@@ -237,18 +250,25 @@ export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
       { failOnNonZeroExit: false }
     ).then(result => {
       const primaryResource = result.stdout.trim();
+      cy.task('log', `[ENABLE_CACHING] primary-resource="${primaryResource}" (code=${result.code})`);
 
       if (primaryResource) {
         const parts = primaryResource.split('/');
         const patchJson = JSON.stringify({
           spec: { kiali_internal: { graph_cache: { enabled: true }, health_cache: { enabled: true } } }
         });
-        cy.exec(`kubectl patch kiali ${parts[1]} -n ${parts[0]} --type merge -p '${patchJson}'`).then(() =>
-          doRestart()
-        );
+        cy.task('log', `[ENABLE_CACHING] Operator path: patching kiali ${parts[1]} -n ${parts[0]} with ${patchJson}`);
+        cy.exec(`kubectl patch kiali ${parts[1]} -n ${parts[0]} --type merge -p '${patchJson}'`).then(patchResult => {
+          cy.task(
+            'log',
+            `[ENABLE_CACHING] Patch result: code=${patchResult.code}, stdout="${patchResult.stdout}", stderr="${patchResult.stderr}"`
+          );
+          doRestart();
+        });
         return;
       }
 
+      cy.task('log', `[ENABLE_CACHING] Helm path: updating configmap ${info.configMapName} -n ${info.namespace}`);
       cy.exec(
         `kubectl get configmap ${info.configMapName} -n ${info.namespace} -o jsonpath="{.data.config\\\\.yaml}" > /tmp/kiali-config.yaml`
       );
@@ -257,7 +277,10 @@ export const enableKialiCaching = (existingInfo?: KialiRuntimeInfo): void => {
       );
       cy.exec(
         `kubectl create configmap ${info.configMapName} -n ${info.namespace} --from-file=config.yaml=/tmp/kiali-config.yaml -o yaml --dry-run=client | kubectl apply -f -`
-      ).then(() => doRestart());
+      ).then(() => {
+        cy.task('log', '[ENABLE_CACHING] ConfigMap updated');
+        doRestart();
+      });
     });
   };
 

--- a/plugin/cypress/integration/kiali/common/waypoint.ts
+++ b/plugin/cypress/integration/kiali/common/waypoint.ts
@@ -597,7 +597,7 @@ Then('the user sees the waypoint attribute', () => {
 });
 
 Then('the proxy status is {string}', (status: string) => {
-  cy.get('[data-label=Status]').get(`.icon-${status}`).should('exist');
+  cy.get('[data-test=workload-details-card]').find(`span[class*="icon-${status}"]`).should('be.visible');
 });
 
 Then(
@@ -639,10 +639,10 @@ Then("the {string} subtab doesn't exist", (subtab: string) => {
 
 Then('validates Services data', () => {
   cy.get('[data-test="enrolled-data-title"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', 'productpage');
-  cy.get('[role="grid"]').should('be.visible').get('#pfbadge-S').should('exist');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', 'bookinfo');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', 'namespace');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', 'productpage');
+  cy.get('[role="grid"]').should('be.visible').find('#pfbadge-S').should('exist');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', 'namespace');
 });
 
 Then(
@@ -650,28 +650,28 @@ Then(
   (rows: number, workload: string, ns: string, label: string, badge: string) => {
     cy.get('[data-test="enrolled-data-title"]').should('be.visible');
     cy.get('table tbody tr').should('have.length', rows);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Name"]').and('contain', workload);
-    cy.get('[role="grid"]').should('be.visible').get(`#${badge}`).should('exist');
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Namespace"]').and('contain', ns);
-    cy.get('[role="grid"]').should('be.visible').get('[data-label="Labeled by"]').and('contain', label);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Name"]').should('contain', workload);
+    cy.get('[role="grid"]').should('be.visible').find(`#${badge}`).should('exist');
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', ns);
+    cy.get('[role="grid"]').should('be.visible').find('td[data-label="Labeled by"]').should('contain', label);
   }
 );
 
 Then('validates waypoint Info data for {string}', (type: string) => {
   cy.get('[data-test=waypointfor-title]').should('exist').and('contain', type);
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=RDS]').and('contain', 'IGNORED');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="RDS"]').should('contain', 'IGNORED');
 });
 
 When('the user validates the Ztunnel tab for the {string} namespace', (namespace: string) => {
   openTab('Ztunnel');
   cy.get('#ztunnel-details').should('be.visible').contains('Services').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Service VIP"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Waypoint]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Service VIP"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Waypoint"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   cy.get('#ztunnel-details').should('be.visible').contains('Workloads').click();
-  cy.get('[role="grid"]').should('be.visible').get('[data-label="Pod Name"]').should('be.visible');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Node]');
-  cy.get('[role="grid"]').should('be.visible').get('[data-label=Namespace]').and('contain', 'bookinfo');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Pod Name"]').should('be.visible');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Node"]');
+  cy.get('[role="grid"]').should('be.visible').find('td[data-label="Namespace"]').should('contain', 'bookinfo');
   // Validate filters in the Namespace column
   cy.get('button#filter_select_type-toggle').click();
   cy.contains('div#filter_select_type button', 'Namespace').click();

--- a/plugin/src/kiali/README.md
+++ b/plugin/src/kiali/README.md
@@ -3,5 +3,5 @@
 Copy of Kiali frontend source code
 Kiali frontend source originated from:
 * git ref:    v2.27
-* git commit: 29c2bdd1021a99c933d22311f273cac33f3e36ba
-* GitHub URL: https://github.com/kiali/kiali/tree/29c2bdd1021a99c933d22311f273cac33f3e36ba/frontend/src
+* git commit: 9bd86d1da8776de8a6771abf321bcfae8c4440a2
+* GitHub URL: https://github.com/kiali/kiali/tree/9bd86d1da8776de8a6771abf321bcfae8c4440a2/frontend/src

--- a/plugin/src/kiali/components/Ambient/WaypointLabel.tsx
+++ b/plugin/src/kiali/components/Ambient/WaypointLabel.tsx
@@ -3,7 +3,7 @@ import { PFBadge, PFBadges } from '../Pf/PfBadges';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { KialiIcon } from '../../config/KialiIcon';
 import { infoStyle } from '../../styles/IconStyle';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 export const renderWaypointLabel = (bgsize?: string): React.ReactNode => {
   const badgeSize = bgsize === 'global' || bgsize === 'sm' ? bgsize : 'global';

--- a/plugin/src/kiali/components/Ambient/WaypointWorkloadsTable.tsx
+++ b/plugin/src/kiali/components/Ambient/WaypointWorkloadsTable.tsx
@@ -12,7 +12,7 @@ import {
   TooltipPosition
 } from '@patternfly/react-core';
 import { kialiStyle } from '../../styles/StyleUtils';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { SortableCompareTh } from './ZtunnelConfig';
 import { WaypointInfo, WorkloadInfo } from '../../types/Workload';
 import { isMultiCluster } from '../../config';

--- a/plugin/src/kiali/components/ChatBot/EntryChat/EntryChat.tsx
+++ b/plugin/src/kiali/components/ChatBot/EntryChat/EntryChat.tsx
@@ -5,7 +5,7 @@ import { KialiAppState } from 'store/Store';
 import { ChatEntry, ReferencedDoc } from 'types/Chatbot';
 import { copyToClipboard } from './clipboard';
 import { Alert } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { ResponseTools } from './ResponseTools';
 import userAvatar from '../../../assets/img/kiali/ai/img_avatar-light.svg';
 import aiAvatar from '../../../assets/img/kiali/ai/img-ai-lightbkg.svg';

--- a/plugin/src/kiali/components/ChatBot/NewChat/NewChatModal.tsx
+++ b/plugin/src/kiali/components/ChatBot/NewChat/NewChatModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ActionGroup, Button, Content, Form } from '@patternfly/react-core';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 import { ChatModal } from './ChatModal';
 
 type Props = {

--- a/plugin/src/kiali/components/ChatBot/error.ts
+++ b/plugin/src/kiali/components/ChatBot/error.ts
@@ -1,5 +1,5 @@
 import { ErrorType } from 'types/Chatbot';
-import { t } from 'i18next';
+import { t } from 'utils/I18nUtils';
 
 export type FetchError = {
   json?: {

--- a/plugin/src/kiali/components/Pf/PfBadges.tsx
+++ b/plugin/src/kiali/components/Pf/PfBadges.tsx
@@ -92,6 +92,7 @@ export const PFBadges: { [key: string]: PFBadgeType } = Object.freeze({
   ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadgeType,
   ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadgeType,
   Sidecar: { badge: 'SC', tt: 'Sidecar' } as PFBadgeType,
+  TrafficExtension: { badge: 'TX', tt: 'Istio Traffic Extension' } as PFBadgeType,
   WasmPlugin: { badge: 'WP', tt: 'Istio Wasm Plugin' } as PFBadgeType,
   Telemetry: { badge: 'TM', tt: 'Istio Telemetry' } as PFBadgeType,
   Template: { badge: 'T', tt: 'Template' } as PFBadgeType,

--- a/plugin/src/kiali/mocks/handlers/istio.ts
+++ b/plugin/src/kiali/mocks/handlers/istio.ts
@@ -406,6 +406,7 @@ const createPermissionsForNamespace = (): Record<string, { create: boolean; dele
   'networking.istio.io/v1, Kind=WorkloadGroup': { create: true, delete: true, update: true },
   'networking.istio.io/v1alpha3, Kind=EnvoyFilter': { create: true, delete: true, update: true },
   'telemetry.istio.io/v1, Kind=Telemetry': { create: true, delete: true, update: true },
+  'extensions.istio.io/v1alpha1, Kind=TrafficExtension': { create: true, delete: true, update: true },
   'extensions.istio.io/v1alpha1, Kind=WasmPlugin': { create: true, delete: true, update: true },
   'gateway.networking.k8s.io/v1, Kind=Gateway': { create: true, delete: true, update: true },
   'gateway.networking.k8s.io/v1, Kind=HTTPRoute': { create: true, delete: true, update: true },

--- a/plugin/src/kiali/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/plugin/src/kiali/pages/IstioConfigList/FiltersAndSorts.ts
@@ -166,6 +166,10 @@ export const istioTypeFilter: FilterType = {
       title: 'Telemetry'
     },
     {
+      id: 'TrafficExtension',
+      title: 'TrafficExtension'
+    },
+    {
       id: 'VirtualService',
       title: 'VirtualService'
     },

--- a/plugin/src/kiali/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/plugin/src/kiali/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -79,6 +79,7 @@ describe('IstioConfigList#filterByName', () => {
     expect(filtered.resources[getGVKTypeString(gvkType.VirtualService)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.DestinationRule)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.ServiceEntry)].length).toBe(0);
+    expect(filtered.resources[getGVKTypeString(gvkType.TrafficExtension)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.WasmPlugin)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.Telemetry)].length).toBe(0);
     expect(filtered.resources[getGVKTypeString(gvkType.K8sGateway)].length).toBe(0);

--- a/plugin/src/kiali/types/IstioConfigList.ts
+++ b/plugin/src/kiali/types/IstioConfigList.ts
@@ -53,16 +53,17 @@ export enum gvkType {
   RequestAuthentication = 'RequestAuthentication',
 
   DestinationRule = 'DestinationRule',
-  Gateway = 'Gateway',
   EnvoyFilter = 'EnvoyFilter',
-  Sidecar = 'Sidecar',
+  Gateway = 'Gateway',
   ServiceEntry = 'ServiceEntry',
+  Sidecar = 'Sidecar',
   VirtualService = 'VirtualService',
   WorkloadEntry = 'WorkloadEntry',
   WorkloadGroup = 'WorkloadGroup',
 
-  WasmPlugin = 'WasmPlugin',
   Telemetry = 'Telemetry',
+  TrafficExtension = 'TrafficExtension',
+  WasmPlugin = 'WasmPlugin',
 
   K8sGateway = 'K8sGateway',
   K8sGatewayClass = 'K8sGatewayClass',
@@ -90,16 +91,17 @@ export const dicTypeToGVK: { [key in gvkType]: GroupVersionKind } = {
   [gvkType.RequestAuthentication]: { Group: 'security.istio.io', Version: 'v1', Kind: gvkType.RequestAuthentication },
 
   [gvkType.DestinationRule]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.DestinationRule },
-  [gvkType.Gateway]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Gateway },
   [gvkType.EnvoyFilter]: { Group: 'networking.istio.io', Version: 'v1alpha3', Kind: gvkType.EnvoyFilter },
-  [gvkType.Sidecar]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Sidecar },
+  [gvkType.Gateway]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Gateway },
   [gvkType.ServiceEntry]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.ServiceEntry },
+  [gvkType.Sidecar]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.Sidecar },
   [gvkType.VirtualService]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.VirtualService },
   [gvkType.WorkloadEntry]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadEntry },
   [gvkType.WorkloadGroup]: { Group: 'networking.istio.io', Version: 'v1', Kind: gvkType.WorkloadGroup },
 
-  [gvkType.WasmPlugin]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.WasmPlugin },
   [gvkType.Telemetry]: { Group: 'telemetry.istio.io', Version: 'v1', Kind: gvkType.Telemetry },
+  [gvkType.TrafficExtension]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.TrafficExtension },
+  [gvkType.WasmPlugin]: { Group: 'extensions.istio.io', Version: 'v1alpha1', Kind: gvkType.WasmPlugin },
 
   [gvkType.K8sGateway]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'Gateway' },
   [gvkType.K8sGatewayClass]: { Group: 'gateway.networking.k8s.io', Version: 'v1', Kind: 'GatewayClass' },

--- a/plugin/src/kiali/types/IstioObjects.ts
+++ b/plugin/src/kiali/types/IstioObjects.ts
@@ -1138,6 +1138,41 @@ export interface ServiceEntry extends IstioObject {
   spec: ServiceEntrySpec;
 }
 
+export interface TrafficExtension extends IstioObject {
+  spec: TrafficExtensionSpec;
+}
+
+export interface TrafficExtensionSpec {
+  lua?: TrafficExtensionLuaConfig;
+  match?: TrafficExtensionSelector[];
+  phase?: string;
+  priority?: number;
+  selector?: WorkloadSelector;
+  targetRefs?: Array<{ group?: string; kind: string; name: string; namespace?: string }>;
+  wasm?: TrafficExtensionWasmConfig;
+}
+
+export interface TrafficExtensionWasmConfig {
+  failStrategy?: string;
+  imagePullPolicy?: string;
+  imagePullSecret?: string;
+  pluginConfig?: { [key: string]: any };
+  pluginName?: string;
+  sha256?: string;
+  type?: string;
+  url: string;
+  vmConfig?: { [key: string]: any };
+}
+
+export interface TrafficExtensionLuaConfig {
+  inlineCode: string;
+}
+
+export interface TrafficExtensionSelector {
+  mode?: string;
+  ports?: Array<{ number: number }>;
+}
+
 export interface WasmPlugin extends IstioObject {
   spec: WasmPluginSpec;
 }

--- a/plugin/src/kiali/utils/I18nUtils.ts
+++ b/plugin/src/kiali/utils/I18nUtils.ts
@@ -1,5 +1,5 @@
 import { i18n } from 'i18n';
-import { TOptions } from 'i18next';
+import type { TOptions } from 'i18next';
 import { UseTranslationResponse, useTranslation } from 'react-i18next';
 
 const I18N_NAMESPACE = process.env.I18N_NAMESPACE;


### PR DESCRIPTION
## Summary
- Backport the `sed` fixup from `main` to the copy script (`hack/copy-frontend-src-to-ossmc.sh`) on v2.27
- The script places vendored Cypress tests one directory level deeper than in the kiali repo (`integration/kiali/common/` vs `integration/common/`), so relative imports that reference `cypress/support/` need an extra `../` to resolve correctly
- Without this fix, syncing the kiali frontend produces build errors like: `Could not resolve "../../support/react-utils"`

## Test plan
- [ ] Run `hack/copy-frontend-src-to-ossmc.sh --source-ref v2.27` on the v2.27 branch
- [ ] Verify `plugin/cypress/integration/kiali/common/graph.ts` contains `../../../support/react-utils` (three levels up, not two)
- [ ] Run `cd plugin && yarn build` to confirm no unresolved import errors


Made with [Cursor](https://cursor.com)