### PR TITLE
Remove v1.73 branch references (OSSM 2.6 EOL)

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -6,14 +6,14 @@ on:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
   workflow_call:
     inputs:
       tag_branches:
         description: Branches to bump version (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
 
 jobs:
@@ -113,11 +113,7 @@ jobs:
           hack/update-version-string.sh "$RELEASE_VERSION"
 
           # Commit the changes
-          git add Makefile plugin/package.json
-
-          if [[ $BRANCH != "v1.73" ]]; then
-            git add plugin/plugin-metadata.ts
-          fi
+          git add Makefile plugin/package.json plugin/plugin-metadata.ts
 
           git commit -m "Bump to version $RELEASE_VERSION"
           git push origin $(git rev-parse HEAD):refs/heads/$BRANCH

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -6,7 +6,7 @@ on:
       tag_branches:
         description: Branches to tag (Separate branches by commas)
         required: true
-        default: v1.73,v2.4,v2.11,v2.17,v2.22
+        default: v2.4,v2.11,v2.17,v2.22
         type: string
 
 permissions: read-all

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@ The currently supported OSSMC release branches (which receive backports and secu
 | 3.2   | v2.17  | 2.17          |
 | 3.1   | v2.11  | 2.11          |
 | 3.0   | v2.4   | 2.4           |
-| 2.6   | v1.73  | 1.73          |
 
 In addition, `main` is the active development branch for the next release.
 

--- a/plugin/cypress/README.md
+++ b/plugin/cypress/README.md
@@ -6,7 +6,7 @@ These are visual tests for OSSMC plugin that are meant to be run against a live 
 
 Installed all dev dependencies from plugin folder. Ensure the `baseUrl` field in the `cypress.config.ts` file is pointing to the console you are trying to test, alternatively you can set `CYPRESS_BASE_URL` environment variable or pass via cmd line `yarn cypress --config baseUrl=http://localhost:9000` to overwrite default `baseUrl`.
 
-Cypress runtime utilizes `download-hack-scripts.sh`, which checks out the hack scripts of `kiali/kiali`. If the OSSMC branch is a release branch (v1.XX), the Kiali branch will be the same. Otherwise, the hack scripts will be downloaded from branch `v1.73` of `kiali/kiali`.
+Cypress runtime utilizes `download-hack-scripts.sh`, which checks out the hack scripts of `kiali/kiali`. If the OSSMC branch is a release branch (v*.X), the Kiali branch will be the same. Otherwise, the hack scripts will be downloaded from the `master` branch of `kiali/kiali`.
 
 Before you start using Cypress suite, you might need export some environment variables:
 


### PR DESCRIPTION
## Summary
- Remove `v1.73` from the default branch lists in the `tag-release-creator` and `bump-release-version` workflows
- Remove the v1.73-specific conditional that skipped `plugin-metadata.ts` during version bumps
- Update Cypress README to reflect the actual `download-hack-scripts.sh` fallback behavior (`master`, not `v1.73`)
- Remove the OSSM 2.6 / v1.73 row from the supported branches table in `AGENTS.md`

## Test plan
- [ ] Verify `tag-release-creator` workflow input defaults no longer include `v1.73`
- [ ] Verify `bump-release-version` workflow input defaults no longer include `v1.73`
- [ ] Verify the v1.73 conditional block is removed and `plugin-metadata.ts` is always staged
- [ ] Confirm no remaining v1.73 version references outside vendored `plugin/src/kiali/` assets

Part of https://github.com/kiali/kiali/issues/9987

Made with [Cursor](https://cursor.com)