### PR TITLE
Add fork workflow rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -621,6 +621,12 @@ If `plugin/src/kiali/` or `plugin/cypress/integration/kiali/` shows up with chan
 > These steps require Kiali organization membership. Skip if you don't
 > have org access.
 
+### Fork Workflow
+
+**NEVER push feature branches directly to the upstream `kiali/openshift-servicemesh-plugin` (or any `kiali/*`) repository.** Always push to the developer's personal fork and create PRs from there. Before pushing, run `git remote -v` to identify which remote is the fork (the one with the developer's username) and which is upstream (`kiali/*`). If no fork remote exists, ask the user.
+
+### Project Management
+
 Every PR must be added to the Kiali GitHub Project with the correct
 status and assignee.
 


### PR DESCRIPTION
## Summary

- Add a "Fork Workflow" rule to the Creating Pull Requests section of AGENTS.md
- Instructs AI agents to never push feature branches directly to upstream `kiali/*` repositories
- Agents must identify the developer's fork remote and push there instead

## Context

Equivalent change to [kiali/kiali#10011](https://github.com/kiali/kiali/pull/10011). AI agents (e.g., Cursor) sometimes push feature branches directly to the upstream `kiali/openshift-servicemesh-plugin` repo instead of the developer's fork. This clutters the main repository with feature branches.

## Test plan

- N/A — documentation-only change


Made with [Cursor](https://cursor.com)