### PR TITLE
Upgrade prettier, pretty-quick, and husky to latest major versions

### DIFF
--- a/plugin/.husky/pre-commit
+++ b/plugin/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 cd plugin
 yarn pre-commit

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -42,7 +42,7 @@
     "lint:gherkin:precommit": "if git diff --cached --name-only | grep -E '\\.feature$'; then npm run lint:gherkin; else true; fi",
     "lint:precommit": "if git diff --name-only HEAD | grep -E '\\.tsx?$'; then npm run lint; else true; fi",
     "prettier": "prettier --write \"**/*.{ts,tsx,scss,json}\"",
-    "prepare": "cd .. && husky install plugin/.husky",
+    "prepare": "cd .. && husky plugin/.husky",
     "pre-commit": "yarn run pretty-quick --staged --no-restage --bail --pattern ['**/*.{ts,tsx,scss,json}', '!src/kiali'] && npm run lint:precommit && npm run lint:gherkin:precommit"
   },
   "dependencies": {
@@ -129,7 +129,7 @@
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "gherkin-lint": "^4.2.4",
     "globals": "^16.2.0",
-    "husky": "^8.0.3",
+    "husky": "^9.1.7",
     "i18next-parser": "^9.4.0",
     "jsdom": "^29.1.1",
     "junit-report-merger": "^9.0.4",
@@ -137,8 +137,8 @@
     "mocha-junit-reporter": "^2.2.1",
     "msw": "^2.12.7",
     "node-polyfill-webpack-plugin": "^2.0.1",
-    "prettier": "^2.4.1",
-    "pretty-quick": "^3.1.3",
+    "prettier": "^3.6.2",
+    "pretty-quick": "^4.2.2",
     "sass": "^1.63.6",
     "sass-loader": "^13.3.0",
     "seedrandom": "^3.0.5",

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -3714,6 +3714,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pkgr/core@npm:^0.2.7":
+  version: 0.2.10
+  resolution: "@pkgr/core@npm:0.2.10"
+  checksum: 10c0/a0ab26e61afc0ed621fdfc03ee07d148c95ab959fcbf426aadbd4710e989dbca509d119ebbc156af33e3072550c7c788271995dbd6594786777ea69592b2f081
+  languageName: node
+  linkType: hard
+
 "@posthog/core@npm:1.14.1":
   version: 1.14.1
   resolution: "@posthog/core@npm:1.14.1"
@@ -6110,13 +6117,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-differ@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "array-differ@npm:3.0.0"
-  checksum: 10c0/c0d924cc2b7e3f5a0e6ae932e8941c5fddc0412bcecf8d5152641910e60f5e1c1e87da2b32083dec2f92f9a8f78e916ea68c22a0579794ba49886951ae783123
-  languageName: node
-  linkType: hard
-
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -6128,20 +6128,6 @@ __metadata:
   version: 1.0.3
   resolution: "array-timsort@npm:1.0.3"
   checksum: 10c0/bd3a1707b621947265c89867e67c9102b9b9f4c50f5b3974220112290d8b60d26ce60595edec5deed3325207b759d70b758bed3cd310b5ddadb835657ffb6d12
-  languageName: node
-  linkType: hard
-
-"array-union@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "array-union@npm:2.1.0"
-  checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
-  languageName: node
-  linkType: hard
-
-"arrify@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "arrify@npm:2.0.1"
-  checksum: 10c0/3fb30b5e7c37abea1907a60b28a554d2f0fc088757ca9bf5b684786e583fdf14360721eb12575c1ce6f995282eab936712d3c4389122682eafab0e0b57f78dbb
   languageName: node
   linkType: hard
 
@@ -6911,16 +6897,6 @@ __metadata:
     escape-string-regexp: "npm:^1.0.5"
     supports-color: "npm:^5.3.0"
   checksum: 10c0/e6543f02ec877732e3a2d1c3c3323ddb4d39fbab687c23f526e25bd4c6a9bf3b83a696e8c769d078e04e5754921648f7821b2a2acfd16c550435fd630026e073
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
   languageName: node
   linkType: hard
 
@@ -9697,7 +9673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:4.1.0, execa@npm:^4.0.0":
+"execa@npm:4.1.0":
   version: 4.1.0
   resolution: "execa@npm:4.1.0"
   dependencies:
@@ -10039,7 +10015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:4.x, find-up@npm:^4.0.0, find-up@npm:^4.1.0":
+"find-up@npm:4.x, find-up@npm:^4.0.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
@@ -11225,12 +11201,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:^8.0.3":
-  version: 8.0.3
-  resolution: "husky@npm:8.0.3"
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
   bin:
-    husky: lib/bin.js
-  checksum: 10c0/6722591771c657b91a1abb082e07f6547eca79144d678e586828ae806499d90dce2a6aee08b66183fd8b085f19d20e0990a2ad396961746b4c8bd5bdb619d668
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
   languageName: node
   linkType: hard
 
@@ -11350,7 +11326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.4, ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
@@ -14079,7 +14055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mri@npm:^1.1.0, mri@npm:^1.1.5":
+"mri@npm:^1.1.0, mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
   checksum: 10c0/a3d32379c2554cf7351db6237ddc18dc9e54e4214953f3da105b97dc3babe0deb3ffe99cf409b38ea47cc29f9430561ba6b53b24ab8f9ce97a4b50409e4a50e7
@@ -14149,19 +14125,6 @@ __metadata:
   bin:
     multicast-dns: cli.js
   checksum: 10c0/5120171d4bdb1577764c5afa96e413353bff530d1b37081cb29cccc747f989eb1baf40574fe8e27060fc1aef72b59c042f72b9b208413de33bcf411343c69057
-  languageName: node
-  linkType: hard
-
-"multimatch@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "multimatch@npm:4.0.0"
-  dependencies:
-    "@types/minimatch": "npm:^3.0.3"
-    array-differ: "npm:^3.0.0"
-    array-union: "npm:^2.1.0"
-    arrify: "npm:^2.0.1"
-    minimatch: "npm:^3.0.4"
-  checksum: 10c0/08e6b71ea2eee2feba17bb4159d247b78d26f9a9b556abddc136c05baa5eba9d80717986e494972284947e9c0e26a19eba3fe20851463fa3dbb770e289f7a0b8
   languageName: node
   linkType: hard
 
@@ -14618,7 +14581,7 @@ __metadata:
     fork-ts-checker-webpack-plugin: "npm:^8.0.0"
     gherkin-lint: "npm:^4.2.4"
     globals: "npm:^16.2.0"
-    husky: "npm:^8.0.3"
+    husky: "npm:^9.1.7"
     i18next: "npm:^23.10.0"
     i18next-http-backend: "npm:^2.5.0"
     i18next-parser: "npm:^9.4.0"
@@ -14633,8 +14596,8 @@ __metadata:
     monaco-editor: "npm:^0.55.1"
     msw: "npm:^2.12.7"
     node-polyfill-webpack-plugin: "npm:^2.0.1"
-    prettier: "npm:^2.4.1"
-    pretty-quick: "npm:^3.1.3"
+    prettier: "npm:^3.6.2"
+    pretty-quick: "npm:^4.2.2"
     react: "npm:^17.0.1"
     react-copy-to-clipboard: "npm:5.x"
     react-dom: "npm:^17.0.1"
@@ -15011,6 +14974,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.2":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^4.0.3":
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
@@ -15239,12 +15209,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.4.1":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
+"prettier@npm:^3.6.2":
+  version: 3.9.5
+  resolution: "prettier@npm:3.9.5"
   bin:
-    prettier: bin-prettier.js
-  checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
+    prettier: bin/prettier.cjs
+  checksum: 10c0/0349dd9e6d8010965de6f69e6b6ee2484b8caf78c66675afced6c75ad60ff24c3a2a4f41153fb8adeaee4d8f539641b48cebc71d283cec4d146e9962126c5ceb
   languageName: node
   linkType: hard
 
@@ -15266,21 +15236,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-quick@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "pretty-quick@npm:3.1.3"
+"pretty-quick@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "pretty-quick@npm:4.2.2"
   dependencies:
-    chalk: "npm:^3.0.0"
-    execa: "npm:^4.0.0"
-    find-up: "npm:^4.1.0"
-    ignore: "npm:^5.1.4"
-    mri: "npm:^1.1.5"
-    multimatch: "npm:^4.0.0"
+    "@pkgr/core": "npm:^0.2.7"
+    ignore: "npm:^7.0.5"
+    mri: "npm:^1.2.0"
+    picocolors: "npm:^1.1.1"
+    picomatch: "npm:^4.0.2"
+    tinyexec: "npm:^0.3.2"
+    tslib: "npm:^2.8.1"
   peerDependencies:
-    prettier: ">=2.0.0"
+    prettier: ^3.0.0
   bin:
-    pretty-quick: bin/pretty-quick.js
-  checksum: 10c0/4d52119b8247f398898347eb5a0166622c7bd9662b31dad05d19397f9ad3c2fea8318f95aec53993343d363f03c229c18b0934310b2bb27c23d33ea4a7ea04b0
+    pretty-quick: lib/cli.mjs
+  checksum: 10c0/3062677741d144e0439971f24742b39eb1ae78b263c5431b2d320b98a4d91de033e1a0b91267c2df7b51159f37446d250c6e33c094b56aa1185e6a4c38d5604f
   languageName: node
   linkType: hard
 
@@ -17807,6 +17778,13 @@ __metadata:
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to kiali/kiali#9708.

## Summary
- `prettier`: ^2.4.1 → ^3.6.2
- `pretty-quick`: ^3.1.3 → ^4.2.2
- `husky`: ^8.0.3 → ^9.1.7
- Updated `.husky/pre-commit`: removed the `husky.sh` sourcing line, which was removed in husky v9
- Updated the `prepare` script: `husky install` → `husky` (v9 CLI syntax change)

**Formatting note:** Prettier 3 flags ~927 pre-existing files for reformatting due to new default style rules. Per the same guidance from @jshaughn and @ferhoyos on the kiali/kiali#9708 PR, this is left out of scope — formatting will be applied incrementally to touched files rather than as a bulk reformat here.

## Test plan
- [x] `yarn lint` — 0 errors (23 pre-existing warnings, unrelated to this change)
- [x] `yarn test` — 75/75 tests passing
- [x] `npx prettier --check` — confirms scope of pre-existing formatting drift (~927 files), none modified by this PR
- [x] Pre-commit hook (`pretty-quick`, `lint:precommit`, `lint:gherkin:precommit`) verified working under husky v9

Co-authored-by: Claude <noreply@anthropic.com>