### PR TITLE
CVE-2026-49978: Upgrade dompurify to 3.4.7+

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -153,6 +153,7 @@
     "webpack-dev-server": "^5.2.1"
   },
   "resolutions": {
+    "dompurify": "^3.4.7",
     "immutable": "^4.3.8",
     "js-cookie": "^3.0.8",
     "lodash": "^4.18.0",

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -8727,27 +8727,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
+"dompurify@npm:^3.4.7":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/d41bb31a72f1acdf9b84c56723c549924b05d92a39a15bd8c40bec9007ff80d5fccf844bc53ee12af5b69044f9a7ce24a1e71c267a4f49cf38711379ed8c1363
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "dompurify@npm:3.3.1"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 10c0/fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
+  checksum: 10c0/127a13817353d4e20e75a991a9022a04c3af12af7479f68e2b8bee6dbc7330a96edfb8f4ebff96f4f0f24cd43e8dbba46214131f510c3aa87a843bd8b610d0ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
DOMPurify prior to 3.4.7 has an IN_PLACE sanitization bypass via shadow contents in `<template>.content`, allowing attacker-controlled markup to survive and execute (XSS).

Add a resolutions entry to force dompurify >= 3.4.7. This consolidates the two transitive entries (3.2.7 from monaco-editor, 3.3.1 from posthog-js) into a single 3.4.12 resolution.

Made with [Cursor](https://cursor.com)