### PR TITLE
CVE-2026-59877: Upgrade protobufjs to 7.6.5

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -157,7 +157,7 @@
     "immutable": "^4.3.8",
     "js-cookie": "^3.0.8",
     "lodash": "^4.18.0",
-    "protobufjs": "^7.5.6",
+    "protobufjs": "^7.6.5",
     "react-markdown": "^8.0.7",
     "unist-util-visit-parents": "^5.1.3",
     "webpack": "^5.104.1"

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -15317,9 +15317,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.5.6":
-  version: 7.6.4
-  resolution: "protobufjs@npm:7.6.4"
+"protobufjs@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -15332,7 +15332,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.3.2"
-  checksum: 10c0/6403eaa9c5a72cc6450c11f38fefafdde243fd806e7ac606ac8d591bc3fdaec45ae764febf83181a2d9aac51aca624e0f46dec368ceea191f7e85e2d6ccaaf93
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump the `protobufjs` resolution from `^7.5.6` to `^7.6.5` to address CVE-2026-59877 (Denial of Service via crafted `.proto` schema).

## Test plan

- [ ] CI passes


Made with [Cursor](https://cursor.com)