### PR TITLE
Upgrade react-resize-detector to v12 and sync related Kiali frontend

### DIFF
--- a/plugin/cypress/integration/kiali/common/istio_config_editor.ts
+++ b/plugin/cypress/integration/kiali/common/istio_config_editor.ts
@@ -2,17 +2,25 @@ import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
 const editIstioConfigYaml = (): void => {
   cy.get('[data-test="istio-config-editor"] .monaco-editor').should('be.visible');
+  // Rendered view-lines prove the full mount+effect cycle completed, so
+  // @monaco-editor/react's onDidChangeModelContent listener is registered.
+  cy.get('[data-test="istio-config-editor"] .view-lines').should('not.be.empty');
+  cy.window().should('have.property', 'istioConfigEditor');
   cy.window().then((win: any) => {
-    const monaco = win.monaco;
-    const editors = monaco.editor.getEditors();
-    const ed = editors[editors.length - 1];
+    const ed = win.istioConfigEditor;
     const model = ed.getModel();
+    expect(model.getLineCount(), 'editor should have YAML content').to.be.greaterThan(1);
+
+    // Use trigger('type') rather than executeEdits. The latter can race with
+    // the @monaco-editor/react useEffect that registers the onChange listener;
+    // trigger('type') flows through Monaco's full input pipeline and reliably
+    // fires onDidChangeModelContent → React onChange → setIsModified(true).
     const lastLine = model.getLineCount();
     const lastCol = model.getLineMaxColumn(lastLine);
-    ed.executeEdits('cypress-test', [{ range: new monaco.Range(lastLine, lastCol, lastLine, lastCol), text: '     ' }]);
+    ed.setPosition({ lineNumber: lastLine, column: lastCol });
+    ed.trigger('cypress-test', 'type', { text: '\n# cypress-unsaved-edit' });
   });
-  // Wait for React to process the isModified state change before proceeding
-  cy.get('button').contains('Save').should('not.be.disabled');
+  cy.contains('button', 'Save').should('not.be.disabled');
 };
 
 When('user updates the {string} AuthorizationPolicy using the text field', (name: string) => {
@@ -20,7 +28,7 @@ When('user updates the {string} AuthorizationPolicy using the text field', (name
     statusCode: 200
   }).as(`${name}-update`);
   editIstioConfigYaml();
-  cy.get('button').contains('Save').should('not.be.disabled').click();
+  cy.contains('button', 'Save').should('not.be.disabled').click();
 });
 
 When('user edits the Istio config YAML', () => {

--- a/plugin/cypress/integration/kiali/common/waypoint.ts
+++ b/plugin/cypress/integration/kiali/common/waypoint.ts
@@ -294,8 +294,8 @@ const waitForHealthyWaypoint = (name: string, namespace: string, cluster?: strin
         responseBody === undefined
           ? 'undefined'
           : typeof responseBody === 'string'
-          ? responseBody
-          : JSON.stringify(responseBody);
+            ? responseBody
+            : JSON.stringify(responseBody);
       const responseBodyShort = responseBodyStr.length > 800 ? `${responseBodyStr.slice(0, 800)}...` : responseBodyStr;
 
       const workload = responseBody;
@@ -550,6 +550,58 @@ Then('the workload description card has no config issues', () => {
   cy.get('[data-test=workload-details-card]').should('be.visible').and('not.contain', 'Config Issues');
 });
 
+// Ambient L7 validation codes from AmbientPolicyChecker (issue #7900).
+// Baseline bookinfo + waypoint enrollment should not produce these warnings.
+const ambientL7ValidationCodes = new Set([
+  'KIA0109',
+  'KIA0110',
+  'KIA0210',
+  'KIA0211',
+  'KIA0212',
+  'KIA1109',
+  'KIA1110',
+  'KIA1111',
+  'KIA1112',
+  'KIA1113',
+  'KIA1114',
+  'KIA1115',
+  'KIA1116',
+  'KIA1117'
+]);
+
+Then('Ambient L7 validation warnings are not present in the {string} namespace', (namespace: string) => {
+  cy.request({ url: `/api/namespaces/${namespace}/istio?validate=true` }).then(response => {
+    expect(response.status).to.eq(200);
+    // API shape: validations[gvk][name.namespace] = { checks: [...] }
+    const validations = response.body?.validations ?? {};
+    const found: string[] = [];
+
+    // TODO: /api/namespaces/{ns}/istio?validate=true still returns cluster-wide validations
+    // (resources are namespaced; validations map is not). Filter client-side until the handler
+    // uses GetValidationsForNamespace. Track in a follow-up issue.
+    Object.keys(validations).forEach(gvk => {
+      const byName = validations[gvk] ?? {};
+      Object.keys(byName).forEach(nameKey => {
+        const entry = byName[nameKey];
+        if (entry?.namespace && entry.namespace !== namespace) {
+          return;
+        }
+        if (!entry?.namespace && !nameKey.endsWith(`.${namespace}`)) {
+          return;
+        }
+        const checks = entry?.checks ?? [];
+        checks.forEach((check: { code?: string; message?: string }) => {
+          if (check.code && ambientL7ValidationCodes.has(check.code)) {
+            found.push(`${gvk}/${nameKey}: ${check.code} ${check.message ?? ''}`.trim());
+          }
+        });
+      });
+    });
+
+    expect(found, `unexpected Ambient L7 validation warnings in ${namespace}`).to.deep.equal([]);
+  });
+});
+
 Then('the user sees the L7 {string} link', (waypoint: string) => {
   cy.get('[data-test=workload-resources-card]').should('contain', 'L7');
   cy.get('[data-test=waypoint-link]').closest('li').find('span').contains('L7');
@@ -562,7 +614,8 @@ Then('the link for the waypoint {string} should redirect to a valid workload det
     .contains('a,button', waypoint)
     .then($el => {
       // In kiosk mode KialiLink renders a button with data-href; in normal mode it renders an anchor.
-      const target = $el.prop('tagName')?.toLowerCase() === 'a' ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+      const target =
+        $el.prop('tagName')?.toLowerCase() === 'a' ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
       expect(target, 'standalone Kiali waypoint link target').to.include(`/workloads/${waypoint}`);
       if (isOSSMC) {
         // Even if the button exist, the click event doesn't work (Even with force).
@@ -583,7 +636,7 @@ Then('the waypoint link points to the {string} cluster', (cluster: string) => {
     const $el = $waypointLink.filter('a, button').add($waypointLink.find('a, button')).first();
     expect($el.length, 'waypoint link element').to.be.greaterThan(0);
 
-    const target = $el.is('a') ? $el.attr('href') ?? '' : $el.attr('data-href') ?? '';
+    const target = $el.is('a') ? ($el.attr('href') ?? '') : ($el.attr('data-href') ?? '');
     expect(target).to.include(`clusterName=${cluster}`);
   });
 });

--- a/plugin/cypress/integration/kiali/featureFiles/waypoint.feature
+++ b/plugin/cypress/integration/kiali/featureFiles/waypoint.feature
@@ -123,6 +123,11 @@ Feature: Kiali Waypoint related features
     And user selects the "bookinfo" namespace
     Then the "K8sGateway" object in "bookinfo" namespace with "waypoint" name Istio Config is valid
 
+  Scenario: [Istio Config] Bookinfo Ambient namespace has no Ambient L7 validation warnings
+    Given user is at the "istio" page
+    And user selects the "bookinfo" namespace
+    Then Ambient L7 validation warnings are not present in the "bookinfo" namespace
+
   Scenario: [Namespaces] Namespace is labeled with the waypoint labels
     Given user is at the "namespaces" list page
     When user selects filter "Namespace"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -74,7 +74,7 @@
     "react-flexview": "4.0.3",
     "react-i18next": "^11.7.3",
     "react-redux": "7.2.9",
-    "react-resize-detector": "9.1.1",
+    "react-resize-detector": "^12.3.0",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
     "react-router-dom-v5-compat": "^6.30.3",

--- a/plugin/src/kiali/README.md
+++ b/plugin/src/kiali/README.md
@@ -3,5 +3,5 @@
 Copy of Kiali frontend source code
 Kiali frontend source originated from:
 * git ref:    master
-* git commit: 8fb0a500f6550bf51f4893db1b3b218e12373833
-* GitHub URL: https://github.com/kiali/kiali/tree/8fb0a500f6550bf51f4893db1b3b218e12373833/frontend/src
+* git commit: dc7cb20edfdc6da73fbdd8c2753c5cb48afb340c
+* GitHub URL: https://github.com/kiali/kiali/tree/dc7cb20edfdc6da73fbdd8c2753c5cb48afb340c/frontend/src

--- a/plugin/src/kiali/components/Tour/TourStop.tsx
+++ b/plugin/src/kiali/components/Tour/TourStop.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
+import type { PopoverPosition } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { KialiDispatch } from 'types/Redux';
-import { KialiAppState } from 'store/Store';
-import ReactResizeDetector from 'react-resize-detector';
+import type { KialiDispatch } from 'types/Redux';
+import type { KialiAppState } from 'store/Store';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { TourActions } from 'actions/TourActions';
 import { kialiStyle } from 'styles/StyleUtils';
 import { PFColors } from 'components/Pf/PfColors';
@@ -77,60 +78,17 @@ export function getNextTourStop(
   return undefined;
 }
 
-class TourStopComponent extends React.PureComponent<TourStopProps> {
-  tourStopInfo: TourStopInfo[];
+const TourStopComponent: React.FC<TourStopProps> = props => {
+  const { activeStop, activeTour, children, endTour, info, setStop } = props;
 
-  constructor(props: TourStopProps) {
-    super(props);
+  const [tourStopInfo] = React.useState<TourStopInfo[]>(() => (Array.isArray(info) ? info : [info]));
 
-    this.tourStopInfo = Array.isArray(props.info) ? props.info : [props.info];
-  }
+  const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  private getStop = (direction: 'back' | 'forward'): number | undefined => {
-    if (this.props.activeStop === undefined) {
-      return undefined;
-    }
-
-    return getNextTourStop(this.props.activeTour!, this.props.activeStop!, direction);
-  };
-
-  private setStop = (stop: number): void => {
-    this.props.setStop(stop);
-  };
-
-  private backButton = (): React.ReactNode => {
-    const stop = this.getStop('back');
-
-    return (
-      <Button isDisabled={stop === undefined} variant={ButtonVariant.secondary} onClick={() => this.setStop(stop!)}>
-        {t('Back')}
-      </Button>
-    );
-  };
-
-  private nextButton = (): React.ReactNode => {
-    const stop = this.getStop('forward');
-
-    if (stop === undefined) {
-      return (
-        <Button variant={ButtonVariant.primary} onClick={this.props.endTour}>
-          {t('Done')}
-        </Button>
-      );
-    }
-
-    return (
-      <Button variant={ButtonVariant.primary} onClick={() => this.setStop(stop!)}>
-        {t('Next')}
-      </Button>
-    );
-  };
-
-  private activeInfo = (): TourStopInfo | undefined => {
-    for (const tsi of this.tourStopInfo) {
+  const activeInfo = (): TourStopInfo | undefined => {
+    for (const tsi of tourStopInfo) {
       const name = tsi.name;
-      const isActive =
-        this.props.activeTour !== undefined && name === this.props.activeTour.stops[this.props.activeStop!].name;
+      const isActive = activeTour !== undefined && name === activeTour.stops[activeStop!].name;
 
       if (isActive) {
         return tsi;
@@ -140,79 +98,105 @@ class TourStopComponent extends React.PureComponent<TourStopProps> {
     return undefined;
   };
 
-  // This is here to workaround what seems to be a bug.  As far as I know when isVisible is set then outside clicks should not hide
-  // the Popover, but it seems to be happening in certain scenarios. So, if the Popover is still valid, unhide it immediately.
-  private onHidden = (): void => {
-    if (this.activeInfo()) {
-      this.forceUpdate();
+  const getStop = (direction: 'back' | 'forward'): number | undefined => {
+    if (activeStop === undefined) {
+      return undefined;
     }
+
+    return getNextTourStop(activeTour!, activeStop!, direction);
   };
 
-  private onResize = (): void => {
-    if (this.activeInfo()) {
-      this.forceUpdate();
-    }
-  };
-
-  private shouldClose = (): void => {
-    this.props.endTour();
-  };
-
-  componentDidMount(): void {
-    this.tourStopInfo.forEach(ti => (ti.isValid = true));
-  }
-
-  componentWillUnmount(): void {
-    this.tourStopInfo.forEach(ti => (ti.isValid = false));
-  }
-
-  render(): React.ReactNode {
-    const info = this.activeInfo();
-    const offset = info && info.distance ? info.distance : 25;
-    const children = this.props.children;
+  const backButton = (): React.ReactNode => {
+    const stop = getStop('back');
 
     return (
-      <>
-        {info ? (
-          <>
-            <ReactResizeDetector
-              refreshMode={'debounce'}
-              refreshRate={100}
-              skipOnMount={true}
-              handleWidth={true}
-              handleHeight={true}
-              onResize={this.onResize}
-            />
-            <Popover
-              bodyContent={info.description ? t(info.description) : info.htmlDescription}
-              distance={offset}
-              footerContent={
-                <div className={buttonsStyle}>
-                  {this.backButton()}
-                  {this.nextButton()}
-                </div>
-              }
-              headerContent={
-                <div>
-                  <span className={stopNumberStyle}>{this.props.activeStop! + 1}</span>
-                  <span>{t(info.name)}</span>
-                </div>
-              }
-              isVisible={true}
-              onHidden={this.onHidden}
-              position={info.position}
-              shouldClose={(_event, _) => this.shouldClose()}
-            >
-              <>{children}</>
-            </Popover>
-          </>
-        ) : (
-          <>{children}</>
-        )}
-      </>
+      <Button
+        isDisabled={stop === undefined}
+        variant={ButtonVariant.secondary}
+        onClick={() => stop !== undefined && setStop(stop)}
+      >
+        {t('Back')}
+      </Button>
     );
-  }
-}
+  };
+
+  const nextButton = (): React.ReactNode => {
+    const stop = getStop('forward');
+
+    if (stop === undefined) {
+      return (
+        <Button variant={ButtonVariant.primary} onClick={endTour}>
+          {t('Done')}
+        </Button>
+      );
+    }
+
+    return (
+      <Button variant={ButtonVariant.primary} onClick={() => setStop(stop)}>
+        {t('Next')}
+      </Button>
+    );
+  };
+
+  // This is here to workaround what seems to be a bug.  As far as I know when isVisible is set then outside clicks should not hide
+  // the Popover, but it seems to be happening in certain scenarios. So, if the Popover is still valid, unhide it immediately.
+  const handleHidden = (): void => {
+    if (activeInfo()) {
+      forceUpdate();
+    }
+  };
+
+  const handleResize = (): void => {
+    if (activeInfo()) {
+      forceUpdate();
+    }
+  };
+
+  useTopologyResize(handleResize);
+
+  React.useEffect(() => {
+    tourStopInfo.forEach(ti => (ti.isValid = true));
+
+    return () => {
+      tourStopInfo.forEach(ti => (ti.isValid = false));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps, @eslint-react/exhaustive-deps
+  }, []);
+
+  const currentInfo = activeInfo();
+  const offset = currentInfo && currentInfo.distance ? currentInfo.distance : 25;
+
+  return (
+    <>
+      {currentInfo ? (
+        <Popover
+          bodyContent={currentInfo.description ? t(currentInfo.description) : currentInfo.htmlDescription}
+          distance={offset}
+          footerContent={
+            <div className={buttonsStyle}>
+              {backButton()}
+              {nextButton()}
+            </div>
+          }
+          headerContent={
+            <div>
+              <span className={stopNumberStyle}>{activeStop! + 1}</span>
+              <span>{t(currentInfo.name)}</span>
+            </div>
+          }
+          isVisible={true}
+          onHidden={handleHidden}
+          position={currentInfo.position}
+          shouldClose={(_event, _) => endTour()}
+        >
+          <>{children}</>
+        </Popover>
+      ) : (
+        <>{children}</>
+      )}
+    </>
+  );
+};
 
 const mapStateToProps = (state: KialiAppState): ReduxStateProps => ({
   activeTour: state.tourState.activeTour,

--- a/plugin/src/kiali/pages/Graph/Graph.tsx
+++ b/plugin/src/kiali/pages/Graph/Graph.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import ReactResizeDetector from 'react-resize-detector';
-import {
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
+import type {
   Controller,
+  EdgeModel,
+  GraphElement,
+  GraphModel,
+  Model,
+  Node,
+  NodeModel,
+  Edge,
+  GraphAreaSelectedEventListener,
+  GraphLayoutEndEventListener
+} from '@patternfly/react-topology';
+import {
   createTopologyControlButtons,
   defaultControlButtonsOptions,
   EdgeAnimationSpeed,
-  EdgeModel,
   EdgeStyle,
-  GraphElement,
-  GraphModel,
   GRAPH_LAYOUT_END_EVENT,
-  Model,
   ModelKind,
-  Node,
-  NodeModel,
   SELECTION_STATE,
   TopologyControlBar,
   TopologyView,
@@ -23,51 +28,35 @@ import {
   Visualization,
   VisualizationProvider,
   VisualizationSurface,
-  Edge,
-  GraphAreaSelectedEventListener,
-  GRAPH_AREA_SELECTED_EVENT,
-  GraphLayoutEndEventListener
+  GRAPH_AREA_SELECTED_EVENT
 } from '@patternfly/react-topology';
-import {
-  BoxByType,
-  EdgeLabelMode,
-  EdgeMode,
-  FocusNode,
-  GraphLayout,
-  LayoutType,
-  NodeAttr,
-  NodeType,
-  RankMode,
-  RankResult,
-  SummaryData,
-  UNKNOWN
-} from 'types/Graph';
-import { JaegerTrace } from 'types/TracingInfo';
+import type { EdgeLabelMode, FocusNode, RankResult, SummaryData } from 'types/Graph';
+import { BoxByType, EdgeMode, GraphLayout, LayoutType, NodeAttr, NodeType, RankMode, UNKNOWN } from 'types/Graph';
+import type { JaegerTrace } from 'types/TracingInfo';
 import { stylesComponentFactory } from './components/stylesComponentFactory';
 import { elementFactory } from '../Graph/elements/elementFactory';
+import type { EdgeData, GraphSettings, NodeData } from './GraphElems';
 import {
   assignEdgeHealth,
-  EdgeData,
   getNodeShape,
   getNodeStatus,
-  GraphSettings,
-  NodeData,
   setEdgeOptions,
   setNodeAttachments,
   setNodeLabel
 } from './GraphElems';
-import { elems, selectAnd, SelectAnd, setObserved } from 'helpers/GraphHelpers';
+import type { SelectAnd } from 'helpers/GraphHelpers';
+import { elems, selectAnd, setObserved } from 'helpers/GraphHelpers';
 import { layoutFactory } from './layouts/layoutFactory';
 import { hideTrace, showTrace } from './Trace';
-import { TimeInMilliseconds } from 'types/Common';
+import type { TimeInMilliseconds } from 'types/Common';
 import { HistoryManager, URLParam } from 'app/History';
 import { TourStop } from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { getValidGraphLayout, supportsGroups } from 'utils/GraphUtils';
-import { GraphData, GraphRefs } from './GraphPage';
-import { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
-import { ServiceDetailsInfo } from 'types/ServiceInfo';
-import { PeerAuthentication } from 'types/IstioObjects';
+import type { GraphData, GraphRefs } from './GraphPage';
+import type { WizardAction, WizardMode } from 'components/IstioWizards/WizardActions';
+import type { ServiceDetailsInfo } from 'types/ServiceInfo';
+import type { PeerAuthentication } from 'types/IstioObjects';
 import { KialiIcon } from 'config/KialiIcon';
 import { toolbarActiveStyle } from 'styles/GraphStyle';
 import { scoreNodes, ScoringCriteria } from 'pages/Graph/GraphScore';
@@ -301,6 +290,8 @@ const TopologyContent: React.FC<{
     graphLayout(controller, LayoutType.Resize);
   }, [controller]);
 
+  useTopologyResize(handleResize);
+
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`TG: onLayoutEnd layoutInProgress=${layoutInProgress}`);
 
@@ -377,7 +368,7 @@ const TopologyContent: React.FC<{
     // Manage the GraphData / DataModel
     //
     const generateDataModel = (): { edges: EdgeModel[]; nodes: NodeModel[] } => {
-      let nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
+      const nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
       const edges: EdgeModel[] = [];
 
       const onHover = (element: GraphElement, isMouseIn: boolean): void => {
@@ -473,7 +464,7 @@ const TopologyContent: React.FC<{
       });
 
       // Compute rank result if enabled
-      let scoringCriteria: ScoringCriteria[] = [];
+      const scoringCriteria: ScoringCriteria[] = [];
 
       if (showRank) {
         for (const ranking of rankBy) {
@@ -486,8 +477,7 @@ const TopologyContent: React.FC<{
           }
         }
 
-        let upperBound = 0;
-        ({ upperBound } = scoreNodes(graphData.elements, ...scoringCriteria));
+        const { upperBound } = scoreNodes(graphData.elements, ...scoringCriteria);
 
         if (setRankResult) {
           setRankResult({ upperBound });
@@ -562,7 +552,7 @@ const TopologyContent: React.FC<{
       // pre-select node-graph node, only when elems have changed (like on first render, or a structural change)
       const graphNode = graphData.fetchParams.node;
       if (graphNode && graphData.elementsChanged) {
-        let selector: SelectAnd = [
+        const selector: SelectAnd = [
           { prop: NodeAttr.namespace, val: graphNode.namespace.name },
           { prop: NodeAttr.nodeType, val: graphNode.nodeType }
         ];
@@ -743,28 +733,12 @@ const TopologyContent: React.FC<{
 
   return isMiniGraph ? (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView data-test="topology-view-pf">
         <VisualizationSurface data-test="visualization-surface" state={{}} />
       </TopologyView>
     </>
   ) : (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView
         data-test="topology-view-pf"
         controlBar={

--- a/plugin/src/kiali/pages/Graph/GraphHelpFind.tsx
+++ b/plugin/src/kiali/pages/Graph/GraphHelpFind.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import ReactResizeDetector from 'react-resize-detector';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
-import { ThProps, IRow } from '@patternfly/react-table';
+import type { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { PFColors } from 'components/Pf/PfColors';
@@ -50,9 +50,11 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
   // Incrementing mock counter to force a re-render in React hooks
   const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  const onResize = (): void => {
+  const handleResize = (): void => {
     forceUpdate();
   };
+
+  useTopologyResize(handleResize);
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
@@ -217,15 +219,6 @@ export const GraphHelpFind: React.FC<GraphHelpFindProps> = (props: GraphHelpFind
 
   return (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        skipOnMount={true}
-        handleWidth={true}
-        handleHeight={true}
-        onResize={onResize}
-      />
-
       {props.isVisible ? (
         <Popover
           data-test="graph-find-hide-help"

--- a/plugin/src/kiali/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/plugin/src/kiali/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -657,6 +657,7 @@ const IstioConfigDetailsPageComponent: React.FC<IstioConfigDetailsProps> = (prop
       monacoEditorRef.current = ed;
       monacoRef.current = monaco;
       (window as any).monaco = monaco;
+      (window as any).istioConfigEditor = ed;
       cursorDisposableRef.current?.dispose();
       cursorDisposableRef.current = ed.onDidChangeCursorPosition(handleCursorChange);
       applyValidationMarkers();

--- a/plugin/src/kiali/pages/Mesh/Mesh.tsx
+++ b/plugin/src/kiali/pages/Mesh/Mesh.tsx
@@ -1,20 +1,25 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import ReactResizeDetector from 'react-resize-detector';
-import {
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
+import type {
   Controller,
+  EdgeModel,
+  GraphElement,
+  GraphModel,
+  Model,
+  Node,
+  NodeModel,
+  Edge,
+  GraphLayoutEndEventListener,
+  GraphAreaSelectedEventListener
+} from '@patternfly/react-topology';
+import {
   createTopologyControlButtons,
   defaultControlButtonsOptions,
   EdgeAnimationSpeed,
-  EdgeModel,
   EdgeStyle,
-  GraphElement,
-  GraphModel,
   GRAPH_LAYOUT_END_EVENT,
-  Model,
   ModelKind,
-  Node,
-  NodeModel,
   SELECTION_STATE,
   TopologyControlBar,
   TopologyView,
@@ -23,23 +28,20 @@ import {
   Visualization,
   VisualizationProvider,
   VisualizationSurface,
-  Edge,
-  GraphLayoutEndEventListener,
-  GraphAreaSelectedEventListener,
   GRAPH_AREA_SELECTED_EVENT
 } from '@patternfly/react-topology';
 import { elementFactory } from './elements/ElementFactory';
 import { getValidMeshLayout, layoutFactory, MeshLayoutType, MeshLayout } from './layouts/LayoutFactory';
-import { TimeInMilliseconds } from 'types/Common';
+import type { TimeInMilliseconds } from 'types/Common';
 import { HistoryManager, URLParam } from 'app/History';
 import { TourStop } from 'components/Tour/TourStop';
 import { meshComponentFactory } from './components/MeshComponentFactory';
-import { MeshData, MeshRefs } from './MeshPage';
-import { MeshInfraType, MeshTarget, MeshType } from 'types/Mesh';
+import type { MeshData, MeshRefs } from './MeshPage';
+import type { MeshTarget } from 'types/Mesh';
+import { MeshInfraType, MeshType } from 'types/Mesh';
 import { MeshHighlighter } from './MeshHighlighter';
+import type { EdgeData, NodeData } from './MeshElems';
 import {
-  EdgeData,
-  NodeData,
   assignEdgeHealth,
   getNodeShape,
   getNodeStatus,
@@ -174,6 +176,8 @@ const TopologyContent: React.FC<{
     layoutMesh(controller, MeshLayoutType.Resize);
   }, [controller]);
 
+  useTopologyResize(handleResize);
+
   const onLayoutEnd = React.useCallback(() => {
     console.debug(`onLayoutEnd layoutInProgress=${layoutInProgress}`);
 
@@ -241,7 +245,7 @@ const TopologyContent: React.FC<{
     // Manage the GraphData / DataModel
     //
     const generateDataModel = (): { edges: EdgeModel[]; nodes: NodeModel[] } => {
-      let nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
+      const nodeMap: Map<string, NodeModel> = new Map<string, NodeModel>();
       const edges: EdgeModel[] = [];
 
       const onHover = (element: GraphElement, isMouseIn: boolean): void => {
@@ -466,25 +470,12 @@ const TopologyContent: React.FC<{
 
   console.debug(`Render Topology hasGraph=${controller.hasGraph()}`);
 
-  // TODO: I expected to find some sort of "onResize" hook in PFT, but after looking at the code
-  // I ended up adding a ReactResizeDetector. It doesn't seem to work perfectly with PFT, but it's
-  // not terrible.  Later I found https://github.com/patternfly/react-topology/issues/62, which
-  // indicates that this is currently the way to go.  I added a suggestion there for some kind
-  // of hook or option, but it would be a future.
   return isMiniMesh ? (
     <TopologyView data-test="mesh-topology-view-pf">
       <VisualizationSurface data-test="mesh-visualization-surface" state={{}} />
     </TopologyView>
   ) : (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        handleWidth={true}
-        handleHeight={true}
-        skipOnMount={true}
-        onResize={handleResize}
-      />
       <TopologyView
         data-test="mesh-topology-view-pf"
         controlBar={

--- a/plugin/src/kiali/pages/Mesh/MeshHelpFind.tsx
+++ b/plugin/src/kiali/pages/Mesh/MeshHelpFind.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import ReactResizeDetector from 'react-resize-detector';
+import { useTopologyResize } from 'utils/ResizeDetectorUtils';
 import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
-import { ThProps, IRow } from '@patternfly/react-table';
+import type { ThProps, IRow } from '@patternfly/react-table';
 import { kialiStyle } from 'styles/StyleUtils';
 import { SimpleTabs } from 'components/Tab/SimpleTabs';
 import { PFColors } from 'components/Pf/PfColors';
@@ -50,9 +50,11 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
   // Incrementing mock counter to force a re-render in React hooks
   const [, forceUpdate] = React.useReducer(x => x + 1, 0);
 
-  const onResize = (): void => {
+  const handleResize = (): void => {
     forceUpdate();
   };
+
+  useTopologyResize(handleResize);
 
   const preface =
     'You can use the Find and Hide fields to highlight or hide mesh nodes and edges. Each field accepts ' +
@@ -153,15 +155,6 @@ export const MeshHelpFind: React.FC<MeshHelpFindProps> = (props: MeshHelpFindPro
 
   return (
     <>
-      <ReactResizeDetector
-        refreshMode="debounce"
-        refreshRate={100}
-        skipOnMount={true}
-        handleWidth={true}
-        handleHeight={true}
-        onResize={onResize}
-      />
-
       {props.isVisible ? (
         <Popover
           data-test="mesh-find-hide-help"

--- a/plugin/src/kiali/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/plugin/src/kiali/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -147,10 +147,13 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
 
     const workloadSelector = wkLabels.join(',');
     if (workloadSelector) {
+      // Resources only: validations for these objects come from getWorkload(?validate=true)
+      // via workload.validations (GetValidationsForWorkload). Avoid pulling cluster/ns-wide
+      // validations from /namespaces/{ns}/istio?validate=true.
       API.getIstioConfig(
         this.props.namespace,
         workloadIstioResources,
-        true,
+        false,
         '',
         workloadSelector,
         this.props.workload.cluster
@@ -218,14 +221,12 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
               (!pod.istioContainers || pod.istioContainers.length === 0) &&
               (!pod.istioInitContainers || pod.istioInitContainers.length === 0)
             ) {
-              if (
-                !(
-                  serverConfig.ambientEnabled &&
-                  (pod.annotations
-                    ? pod.annotations[istioAnnotations.ambientAnnotation] === istioAnnotations.ambientAnnotationEnabled
-                    : false)
-                )
-              ) {
+              if (!(
+                serverConfig.ambientEnabled &&
+                (pod.annotations
+                  ? pod.annotations[istioAnnotations.ambientAnnotation] === istioAnnotations.ambientAnnotationEnabled
+                  : false)
+              )) {
                 validations.pod[pod.name].checks.push(noIstiosidecar);
               }
             } else {
@@ -634,7 +635,15 @@ export class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInf
     const workloadEntries = workload?.workloadEntries ?? [];
 
     const istioConfigItems = skipUnrelatedK8sGateways(
-      this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig, workload?.cluster || '') : [],
+      this.state.workloadIstioConfig
+        ? toIstioItems(
+            {
+              ...this.state.workloadIstioConfig,
+              validations: workload?.validations ?? this.state.workloadIstioConfig.validations ?? {}
+            },
+            workload?.cluster || ''
+          )
+        : [],
       this.props.workload?.labels[AMBIENT_WAYPOINT_GATEWAY_LABEL]
     );
 

--- a/plugin/src/kiali/types/Health.ts
+++ b/plugin/src/kiali/types/Health.ts
@@ -6,14 +6,14 @@ import {
   NewProcessIcon,
   UnknownIcon
 } from '@patternfly/react-icons';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 import { getName } from '../utils/RateIntervals';
 import { PFColors } from 'components/Pf/PfColors';
 import { calculateErrorRate } from './ErrorRate';
-import { ToleranceConfig } from './ServerConfig';
+import type { ToleranceConfig } from './ServerConfig';
 import { serverConfig } from '../config';
-import { HealthAnnotationType } from './HealthAnnotation';
-import { NamespaceStatus } from './NamespaceInfo';
+import type { HealthAnnotationType } from './HealthAnnotation';
+import type { NamespaceStatus } from './NamespaceInfo';
 import { t } from 'utils/I18nUtils';
 
 interface HealthConfig {
@@ -309,8 +309,9 @@ export const mergeStatus = (s1: Status, s2: Status): Status => {
 
 export const ascendingThresholdCheck = (value: number, thresholds: Thresholds): ThresholdStatus => {
   if (value > 0) {
-    // failure === 0 means "unset" / no failure tier (same as business/health_calculator.go applyThresholds).
-    if (thresholds.failure > 0 && value >= thresholds.failure) {
+    // failure: 0 is a valid threshold (docs: value >= FAILURE → Failure), same as
+    // business/health_calculator.go applyThresholds.
+    if (value >= thresholds.failure) {
       return {
         value: value,
         status: FAILURE,
@@ -330,7 +331,7 @@ export const ascendingThresholdCheck = (value: number, thresholds: Thresholds): 
 
 export const getRequestErrorsStatus = (ratio: number, tolerance?: ToleranceConfig): ThresholdStatus => {
   if (tolerance && ratio >= 0) {
-    let thresholds = {
+    const thresholds = {
       degraded: tolerance.degraded,
       failure: tolerance.failure,
       unit: '%'
@@ -383,7 +384,7 @@ export abstract class Health {
     // Check if the config applied is the kiali defaults one
     const tolConfDefault = serverConfig.healthConfig.rate[serverConfig.healthConfig.rate.length - 1].tolerance;
 
-    for (let tol of tolConfDefault) {
+    for (const tol of tolConfDefault) {
       // Check if the tolerance applied is one of kiali defaults
       if (this.health.statusConfig && tol === this.health.statusConfig.threshold) {
         // In the case is a kiali's default return undefined
@@ -429,6 +430,16 @@ interface HealthContext {
 const emptyRequestHealth = (): RequestHealth => ({ inbound: {}, outbound: {}, healthAnnotations: {} });
 
 export class ServiceHealth extends Health {
+  constructor(
+    ns: string,
+    srv: string,
+    public requests: RequestHealth,
+    ctx: HealthContext,
+    backendStatus?: CalculatedHealthStatus
+  ) {
+    super(ServiceHealth.computeItems(ns, srv, requests, ctx), backendStatus);
+  }
+
   public static fromJson = (ns: string, srv: string, json: any, ctx: HealthContext): ServiceHealth =>
     new ServiceHealth(ns, srv, json.requests ?? emptyRequestHealth(), ctx, json.status);
 
@@ -476,19 +487,20 @@ export class ServiceHealth extends Health {
     }
     return { items, statusConfig };
   }
+}
 
+export class AppHealth extends Health {
   constructor(
     ns: string,
-    srv: string,
+    app: string,
+    workloadStatuses: WorkloadStatus[],
     public requests: RequestHealth,
     ctx: HealthContext,
     backendStatus?: CalculatedHealthStatus
   ) {
-    super(ServiceHealth.computeItems(ns, srv, requests, ctx), backendStatus);
+    super(AppHealth.computeItems(ns, app, workloadStatuses, requests, ctx), backendStatus);
   }
-}
 
-export class AppHealth extends Health {
   public static fromJson = (ns: string, app: string, json: any, ctx: HealthContext): AppHealth =>
     new AppHealth(ns, app, json.workloadStatuses ?? [], json.requests ?? emptyRequestHealth(), ctx, json.status);
 
@@ -556,17 +568,6 @@ export class AppHealth extends Health {
 
     return { items, statusConfig };
   }
-
-  constructor(
-    ns: string,
-    app: string,
-    workloadStatuses: WorkloadStatus[],
-    public requests: RequestHealth,
-    ctx: HealthContext,
-    backendStatus?: CalculatedHealthStatus
-  ) {
-    super(AppHealth.computeItems(ns, app, workloadStatuses, requests, ctx), backendStatus);
-  }
 }
 
 const emptyWorkloadStatus = (): WorkloadStatus => ({
@@ -578,6 +579,17 @@ const emptyWorkloadStatus = (): WorkloadStatus => ({
 });
 
 export class WorkloadHealth extends Health {
+  constructor(
+    ns: string,
+    workload: string,
+    workloadStatus: WorkloadStatus,
+    public requests: RequestHealth,
+    ctx: HealthContext,
+    backendStatus?: CalculatedHealthStatus
+  ) {
+    super(WorkloadHealth.computeItems(ns, workload, workloadStatus, requests, ctx), backendStatus);
+  }
+
   public static fromJson = (ns: string, workload: string, json: any, ctx: HealthContext): WorkloadHealth =>
     new WorkloadHealth(
       ns,
@@ -680,17 +692,6 @@ export class WorkloadHealth extends Health {
     }
 
     return { items, statusConfig };
-  }
-
-  constructor(
-    ns: string,
-    workload: string,
-    workloadStatus: WorkloadStatus,
-    public requests: RequestHealth,
-    ctx: HealthContext,
-    backendStatus?: CalculatedHealthStatus
-  ) {
-    super(WorkloadHealth.computeItems(ns, workload, workloadStatus, requests, ctx), backendStatus);
   }
 }
 

--- a/plugin/src/kiali/types/__tests__/Health.test.ts
+++ b/plugin/src/kiali/types/__tests__/Health.test.ts
@@ -1,6 +1,6 @@
 import * as H from '../Health';
 import { DEGRADED, HEALTHY } from '../Health';
-import { ToleranceConfig } from '../ServerConfig';
+import type { ToleranceConfig } from '../ServerConfig';
 import { setServerConfig } from '../../config/ServerConfig';
 import { healthConfig } from '../__testData__/HealthConfig';
 
@@ -71,14 +71,14 @@ describe('Health', () => {
     expect(result.value).toEqual(50);
     expect(result.violation).toEqual('50.00%>=20%');
   });
-  it('should skip failure tier when failure is 0 (matches server applyThresholds)', () => {
+  it('should treat failure: 0 as Failure when there are errors (matches server applyThresholds)', () => {
     const tol: ToleranceConfig = { code: '', degraded: 10, failure: 0 };
-    expect(H.getRequestErrorsStatus(0.15, tol).status).toEqual(H.DEGRADED);
-    expect(H.getRequestErrorsStatus(0.05, tol).status).toEqual(H.HEALTHY);
+    expect(H.getRequestErrorsStatus(0.15, tol).status).toEqual(H.FAILURE);
+    expect(H.getRequestErrorsStatus(0.05, tol).status).toEqual(H.FAILURE);
   });
-  it('should use degraded tier when failure is 0 and degraded is 0 but there are errors', () => {
+  it('should use Failure when failure is 0 and degraded is 0 but there are errors', () => {
     const tol: ToleranceConfig = { code: '', degraded: 0, failure: 0 };
-    expect(H.getRequestErrorsStatus(0.01, tol).status).toEqual(H.DEGRADED);
+    expect(H.getRequestErrorsStatus(0.01, tol).status).toEqual(H.FAILURE);
   });
   it('should get comparable error ratio with NA', () => {
     const r1 = H.getRequestErrorsStatus(-1, toleranceDefault);

--- a/plugin/src/kiali/utils/ResizeDetectorUtils.ts
+++ b/plugin/src/kiali/utils/ResizeDetectorUtils.ts
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { useResizeDetector } from 'react-resize-detector';
+
+export const TOPOLOGY_GRAPH_CONTAINER_ID = 'pft-graph';
+export const TOPOLOGY_MESH_CONTAINER_ID = 'mesh-container';
+
+// Prefer over document.body — side panels resize these containers, not the body.
+// Falls back to document.body when neither container exists (e.g., non-topology pages).
+export const getTopologyResizeTarget = (): HTMLElement =>
+  document.getElementById(TOPOLOGY_GRAPH_CONTAINER_ID) ??
+  document.getElementById(TOPOLOGY_MESH_CONTAINER_ID) ??
+  document.body;
+
+export const useTopologyResize = (onResize: () => void): void => {
+  const resizeTargetRef = React.useRef<HTMLElement>(getTopologyResizeTarget());
+
+  useResizeDetector({
+    targetRef: resizeTargetRef,
+    disableRerender: true,
+    refreshMode: 'debounce',
+    refreshRate: 100,
+    skipOnMount: true,
+    handleWidth: true,
+    handleHeight: true,
+    onResize
+  });
+};

--- a/plugin/src/kiali/utils/__tests__/ResizeDetectorUtils.test.ts
+++ b/plugin/src/kiali/utils/__tests__/ResizeDetectorUtils.test.ts
@@ -1,0 +1,31 @@
+import {
+  getTopologyResizeTarget,
+  TOPOLOGY_GRAPH_CONTAINER_ID,
+  TOPOLOGY_MESH_CONTAINER_ID
+} from '../ResizeDetectorUtils';
+
+describe('getTopologyResizeTarget', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns the graph container when present', () => {
+    const el = document.createElement('div');
+    el.id = TOPOLOGY_GRAPH_CONTAINER_ID;
+    document.body.appendChild(el);
+
+    expect(getTopologyResizeTarget()).toBe(el);
+  });
+
+  it('falls back to mesh container when graph container is absent', () => {
+    const el = document.createElement('div');
+    el.id = TOPOLOGY_MESH_CONTAINER_ID;
+    document.body.appendChild(el);
+
+    expect(getTopologyResizeTarget()).toBe(el);
+  });
+
+  it('falls back to document.body when neither container exists', () => {
+    expect(getTopologyResizeTarget()).toBe(document.body);
+  });
+});

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -9063,6 +9063,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-toolkit@npm:^1.39.6":
+  version: 1.50.0
+  resolution: "es-toolkit@npm:1.50.0"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+    vitepress-plugin-sandpack@1.1.4:
+      unplugged: true
+  checksum: 10c0/80e3a212d337df6f20ed0330d1b62dda25f3ef6d4c83a33f13d521ccbf5b4ad1ac3e7e638572abd6080627f522707de76a5c9360350b713e5392739083ee1f24
+  languageName: node
+  linkType: hard
+
 "es6-object-assign@npm:^1.1.0":
   version: 1.1.0
   resolution: "es6-object-assign@npm:1.1.0"
@@ -14592,7 +14606,7 @@ __metadata:
     react-flexview: "npm:4.0.3"
     react-i18next: "npm:^11.7.3"
     react-redux: "npm:7.2.9"
-    react-resize-detector: "npm:9.1.1"
+    react-resize-detector: "npm:^12.3.0"
     react-router: "npm:5.3.x"
     react-router-dom: "npm:5.3.x"
     react-router-dom-v5-compat: "npm:^6.30.3"
@@ -15711,15 +15725,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-detector@npm:9.1.1":
-  version: 9.1.1
-  resolution: "react-resize-detector@npm:9.1.1"
+"react-resize-detector@npm:^12.3.0":
+  version: 12.3.0
+  resolution: "react-resize-detector@npm:12.3.0"
   dependencies:
-    lodash: "npm:^4.17.21"
+    es-toolkit: "npm:^1.39.6"
   peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/6a85892fe46a12fc27b09b5bf5fcc1438f3196f70c75d4685b09eed2c68a2c853dd6eb792bf852038082505a3b4f05dba359055ee0baca3f8b59f022a85a368c
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10c0/58075af4f7842debc97934bee15947d7ac1db1af8849832258fc986482487de97489d80b15edea6658260edbe826ac8f8acf6c2df2a28e527c8f63a4bff3436f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `react-resize-detector` from 9.1.1 to ^12.3.0 and migrate callers to the hook-based API via a shared `useTopologyResize` helper.
- Sync related Kiali frontend changes from `dc7cb20` (Graph/Mesh/Tour/Workload resize handling, Health updates).
- Include accompanying Cypress updates for Istio config editor edits and Ambient L7 waypoint validation coverage.

## Test plan
- [ ] `cd plugin && yarn install && yarn build`
- [ ] Verify Graph and Mesh resize correctly when side panels open/close
- [ ] Spot-check Tour popovers still reposition on container resize
- [ ] Run unit tests for `ResizeDetectorUtils` and `Health`
- [ ] Run relevant Cypress specs (waypoint / istio config editor) if cluster available


Made with [Cursor](https://cursor.com)