### PR TITLE
Standalone OSSMC with `Istios` and `Kialis` pages

### DIFF
--- a/plugin/console-extensions.ts
+++ b/plugin/console-extensions.ts
@@ -12,6 +12,7 @@ const enum Page {
   GRAPH = 'GraphPage',
   ISTIO = 'IstioConfigListPage',
   ISTIO_NEW = 'IstioConfigNewPage',
+  ISTIOS = 'IstiosPage',
   MESH = 'MeshPage',
   NAMESPACES = 'NamespacesPage',
   OVERVIEW = 'OverviewPage',
@@ -255,6 +256,7 @@ const extensions: EncodedExtension[] = [
       section: OSSM_CONSOLE
     }
   },
+  ...consoleRoute('istios', 'Istios', Page.ISTIOS, [`/${OSSM_CONSOLE}/istios`]),
   ...consoleRoute('namespaces', 'Namespaces', Page.NAMESPACES, [`/${OSSM_CONSOLE}/namespaces`]),
   ...consoleRoute('applications', 'Applications', Page.APPLICATIONS, [`/${OSSM_CONSOLE}/applications`]),
   {

--- a/plugin/console-extensions.ts
+++ b/plugin/console-extensions.ts
@@ -3,6 +3,7 @@ import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 const OSSM_CONSOLE = 'ossmconsole';
 const ADMIN = 'admin';
+const KIALI_REACHABLE = 'KIALI_REACHABLE';
 
 const getConsoleTitle = (title: string) => `%plugin__ossmconsole~${title}%`;
 
@@ -13,6 +14,7 @@ const enum Page {
   ISTIO = 'IstioConfigListPage',
   ISTIO_NEW = 'IstioConfigNewPage',
   ISTIOS = 'IstiosPage',
+  KIALIS = 'KialisPage',
   MESH = 'MeshPage',
   NAMESPACES = 'NamespacesPage',
   OVERVIEW = 'OverviewPage',
@@ -179,11 +181,21 @@ const istioResources: K8sGroupVersionKind[] = [
   }
 ];
 
+const kialiFlag: EncodedExtension = {
+  type: 'console.flag/hookProvider',
+  properties: {
+    handler: { $codeRef: 'KialiFlag.useKialiFlag' }
+  }
+};
+
 const reduxReducer: EncodedExtension = {
   type: 'console.redux-reducer',
   properties: {
     scope: 'kiali',
     reducer: { $codeRef: 'ReduxReducer' }
+  },
+  flags: {
+    required: [KIALI_REACHABLE]
   }
 };
 
@@ -196,14 +208,17 @@ const consoleSection: EncodedExtension = {
   }
 };
 
-const consoleRoute = (id: string, title: string, pageRef: string, paths: string[]): EncodedExtension[] => {
+type Flags = { required?: string[]; disallowed?: string[] };
+
+const consoleRoute = (id: string, title: string, pageRef: string, paths: string[], flags?: Flags): EncodedExtension[] => {
   const routes = paths.map(path => ({
     type: 'console.page/route',
     properties: {
       exact: true,
       path: path,
       component: { $codeRef: pageRef }
-    }
+    },
+    ...(flags && { flags })
   }));
 
   return [
@@ -216,12 +231,13 @@ const consoleRoute = (id: string, title: string, pageRef: string, paths: string[
         href: paths[0],
         perspective: ADMIN,
         section: OSSM_CONSOLE
-      }
+      },
+      ...(flags && { flags })
     }
   ];
 };
 
-const horizontalNav = (model: K8sGroupVersionKind, tabRef: string): EncodedExtension => ({
+const horizontalNav = (model: K8sGroupVersionKind, tabRef: string, flags?: Flags): EncodedExtension => ({
   type: 'console.tab/horizontalNav',
   properties: {
     model: model,
@@ -230,15 +246,19 @@ const horizontalNav = (model: K8sGroupVersionKind, tabRef: string): EncodedExten
       href: OSSM_CONSOLE
     },
     component: { $codeRef: tabRef }
-  }
+  },
+  ...(flags && { flags })
 });
 
+const kialiRequired: Flags = { required: [KIALI_REACHABLE] };
+
 const extensions: EncodedExtension[] = [
+  kialiFlag,
   reduxReducer,
   consoleSection,
 
-  // Console routes for each OSSMC page
-  ...consoleRoute('overview', 'Overview', Page.OVERVIEW, [`/${OSSM_CONSOLE}/overview`]),
+  // Kiali-dependent pages (only shown when Kiali backend is reachable)
+  ...consoleRoute('overview', 'Overview', Page.OVERVIEW, [`/${OSSM_CONSOLE}/overview`], kialiRequired),
   ...consoleRoute('graph', 'Traffic Graph', Page.GRAPH, [
     `/${OSSM_CONSOLE}/graph`,
     `/${OSSM_CONSOLE}/graph/ns/:namespace/aggregates/:aggregate/:aggregateValue`,
@@ -246,59 +266,66 @@ const extensions: EncodedExtension[] = [
     `/${OSSM_CONSOLE}/graph/ns/:namespace/applications/:app`,
     `/${OSSM_CONSOLE}/graph/ns/:namespace/services/:service`,
     `/${OSSM_CONSOLE}/graph/ns/:namespace/workloads/:workload`
-  ]),
-  ...consoleRoute('mesh', 'Mesh', Page.MESH, [`/${OSSM_CONSOLE}/mesh`]),
+  ], kialiRequired),
+  ...consoleRoute('mesh', 'Mesh', Page.MESH, [`/${OSSM_CONSOLE}/mesh`], kialiRequired),
   {
     type: 'console.navigation/separator',
     properties: {
       id: `${OSSM_CONSOLE}_separator`,
       perspective: ADMIN,
       section: OSSM_CONSOLE
-    }
+    },
+    flags: kialiRequired
   },
-  ...consoleRoute('istios', 'Istios', Page.ISTIOS, [`/${OSSM_CONSOLE}/istios`]),
-  ...consoleRoute('namespaces', 'Namespaces', Page.NAMESPACES, [`/${OSSM_CONSOLE}/namespaces`]),
-  ...consoleRoute('applications', 'Applications', Page.APPLICATIONS, [`/${OSSM_CONSOLE}/applications`]),
+  ...consoleRoute('namespaces', 'Namespaces', Page.NAMESPACES, [`/${OSSM_CONSOLE}/namespaces`], kialiRequired),
+  ...consoleRoute('applications', 'Applications', Page.APPLICATIONS, [`/${OSSM_CONSOLE}/applications`], kialiRequired),
   {
     type: 'console.page/route',
     properties: {
       exact: true,
       path: `/${OSSM_CONSOLE}/applications/:namespace/:app`,
       component: { $codeRef: Page.APPLICATION_DETAIL }
-    }
+    },
+    flags: kialiRequired
   },
-  ...consoleRoute('services', 'Services', Page.SERVICES, [`/${OSSM_CONSOLE}/services`]),
+  ...consoleRoute('services', 'Services', Page.SERVICES, [`/${OSSM_CONSOLE}/services`], kialiRequired),
   {
     type: 'console.page/route',
     properties: {
       exact: true,
       path: `/${OSSM_CONSOLE}/services/:namespace/:service`,
       component: { $codeRef: Page.SERVICE_DETAIL }
-    }
+    },
+    flags: kialiRequired
   },
-  ...consoleRoute('workloads', 'Workloads', Page.WORKLOADS, [`/${OSSM_CONSOLE}/workloads`]),
-  ...consoleRoute('istio', 'Istio Config', Page.ISTIO, [`/${OSSM_CONSOLE}/istio`]),
+  ...consoleRoute('workloads', 'Workloads', Page.WORKLOADS, [`/${OSSM_CONSOLE}/workloads`], kialiRequired),
+  ...consoleRoute('istio', 'Istio Config', Page.ISTIO, [`/${OSSM_CONSOLE}/istio`], kialiRequired),
   {
     type: 'console.page/route',
     properties: {
       exact: true,
       path: `/${OSSM_CONSOLE}/istio/new/:objectGroup/:objectVersion/:objectKind`,
       component: { $codeRef: Page.ISTIO_NEW }
-    }
+    },
+    flags: kialiRequired
   },
 
-  // K8s horizontal navs - service mesh tab of k8s resources
-  horizontalNav(K8sResource.Project, Tab.NAMESPACE),
-  horizontalNav(K8sResource.Namespace, Tab.NAMESPACE),
-  horizontalNav(K8sResource.Pod, Tab.WORKLOAD),
-  horizontalNav(K8sResource.Deployment, Tab.WORKLOAD),
-  horizontalNav(K8sResource.DeploymentConfig, Tab.WORKLOAD),
-  horizontalNav(K8sResource.ReplicaSet, Tab.WORKLOAD),
-  horizontalNav(K8sResource.StatefulSet, Tab.WORKLOAD),
-  horizontalNav(K8sResource.DaemonSet, Tab.WORKLOAD),
-  horizontalNav(K8sResource.Service, Tab.SERVICE),
+  // Always-visible pages (no Kiali dependency)
+  ...consoleRoute('istios', 'Istios', Page.ISTIOS, [`/${OSSM_CONSOLE}/istios`]),
+  ...consoleRoute('kialis', 'Kialis', Page.KIALIS, [`/${OSSM_CONSOLE}/kialis`]),
 
-  // Istio horizontal navs - service mesh tab of istio resources
+  // Kiali-dependent horizontal nav tabs
+  horizontalNav(K8sResource.Project, Tab.NAMESPACE, kialiRequired),
+  horizontalNav(K8sResource.Namespace, Tab.NAMESPACE, kialiRequired),
+  horizontalNav(K8sResource.Pod, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.Deployment, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.DeploymentConfig, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.ReplicaSet, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.StatefulSet, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.DaemonSet, Tab.WORKLOAD, kialiRequired),
+  horizontalNav(K8sResource.Service, Tab.SERVICE, kialiRequired),
+
+  // Kiali-dependent Istio horizontal nav tabs
   ...istioResources.map(istioResource => ({
     type: 'console.tab/horizontalNav',
     properties: {
@@ -308,7 +335,8 @@ const extensions: EncodedExtension[] = [
         href: OSSM_CONSOLE
       },
       component: { $codeRef: Tab.ISTIO }
-    }
+    },
+    flags: kialiRequired
   }))
 ];
 

--- a/plugin/plugin-metadata.ts
+++ b/plugin/plugin-metadata.ts
@@ -11,6 +11,7 @@ const metadata: ConsolePluginBuildMetadata = {
     GraphPage: './openshift/pages/GraphPage',
     IstioConfigListPage: './openshift/pages/IstioConfigListPage',
     IstioConfigNewPage: './openshift/pages/IstioConfigNewPage',
+    IstiosPage: './openshift/pages/IstiosPage',
     IstioDetailsTab: './openshift/pages/ServiceMeshTabs/IstioDetailsTab',
     MeshPage: './openshift/pages/MeshPage',
     NamespacesPage: './openshift/pages/NamespacesPage',

--- a/plugin/plugin-metadata.ts
+++ b/plugin/plugin-metadata.ts
@@ -13,6 +13,8 @@ const metadata: ConsolePluginBuildMetadata = {
     IstioConfigNewPage: './openshift/pages/IstioConfigNewPage',
     IstiosPage: './openshift/pages/IstiosPage',
     IstioDetailsTab: './openshift/pages/ServiceMeshTabs/IstioDetailsTab',
+    KialiFlag: './openshift/utils/useKialiFlag',
+    KialisPage: './openshift/pages/KialisPage',
     MeshPage: './openshift/pages/MeshPage',
     NamespacesPage: './openshift/pages/NamespacesPage',
     OverviewPage: './openshift/pages/OverviewPage',

--- a/plugin/src/openshift/__mocks__/consoleSdkMock.ts
+++ b/plugin/src/openshift/__mocks__/consoleSdkMock.ts
@@ -1,5 +1,11 @@
+import * as React from 'react';
 import { rs } from '@rstest/core';
 
 export const consoleFetchJSON = rs.fn();
 export const useActivePerspective = rs.fn(() => ['admin', rs.fn()]);
 export const getGroupVersionKindForResource = rs.fn();
+export const useK8sWatchResources = rs.fn(() => ({}));
+export const ResourceLink: React.FC<Record<string, unknown>> = ({ name }) =>
+  React.createElement('span', null, name as string);
+export const Timestamp: React.FC<Record<string, unknown>> = ({ timestamp }) =>
+  React.createElement('span', null, timestamp as string);

--- a/plugin/src/openshift/components/KialiController.tsx
+++ b/plugin/src/openshift/components/KialiController.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
 import type { Namespace } from 'types/Namespace';
 import { MessageType } from 'types/NotificationCenter';
 import type { DurationInSeconds, IntervalInMilliseconds} from 'types/Common';
@@ -13,6 +15,7 @@ import { PromisesRegistry } from 'utils/CancelablePromises';
 import * as API from 'services/Api';
 import { humanDurations, serverConfig, setServerConfig } from 'config/ServerConfig';
 import { config } from 'config';
+import { t } from 'utils/I18nUtils';
 import type { KialiDispatch } from 'types/Redux';
 import { NotificationCenterActions } from 'actions/NotificationCenterActions';
 import { LoginThunkActions } from 'actions/LoginThunkActions';
@@ -95,7 +98,8 @@ export { netobservPluginConfig };
 
 class KialiControllerComponent extends React.Component<KialiControllerProps> {
   state = {
-    loaded: false
+    loaded: false,
+    kialiReachable: true
   };
 
   private promises = new PromisesRegistry();
@@ -109,6 +113,24 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
   }
 
   render(): React.ReactNode {
+    if (this.state.loaded && !this.state.kialiReachable) {
+      return (
+        <EmptyState
+          headingLevel="h1"
+          icon={CubesIcon}
+          titleText={t('Service Mesh is not configured')}
+          variant={EmptyStateVariant.lg}
+        >
+          <EmptyStateBody>
+            {t(
+              'The OpenShift Service Mesh Console plugin is installed but cannot connect to a Kiali server. ' +
+                'To use Service Mesh features, install and configure a Kiali instance using the Kiali Operator.'
+            )}
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
     return this.state.loaded ? (
       <>{this.props.children}</>
     ) : (
@@ -117,27 +139,30 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
   }
 
   private loadKiali = async (): Promise<void> => {
-    await this.getKialiConfig();
+    const kialiReachable = await this.getKialiConfig();
 
-    this.applyUIDefaults();
+    if (kialiReachable) {
+      this.applyUIDefaults();
+    }
     this.setDocLayout();
-    this.setState({ loaded: true });
+    this.setState({ loaded: true, kialiReachable });
   };
 
-  private getKialiConfig = async (): Promise<void> => {
+  private getKialiConfig = async (): Promise<boolean> => {
+    try {
+      const serverConfigResponse = await this.promises.register('getServerConfig', API.getServerConfig());
+      setServerConfig(serverConfigResponse.data);
+    } catch (error) {
+      console.info('Kiali server is not reachable. Service Mesh features will be unavailable.', error);
+      return false;
+    }
+
     try {
       const getNamespacesPromise = this.promises
         .register('getNamespaces', API.getNamespaces())
         .then(response => this.props.setNamespaces(response.data, new Date()))
         .catch(error => {
           addError('Error fetching namespaces.', error, true, MessageType.WARNING);
-        });
-
-      const getServerConfigPromise = this.promises
-        .register('getServerConfig', API.getServerConfig())
-        .then(response => setServerConfig(response.data))
-        .catch(error => {
-          addError('Error fetching server config.', error, true, MessageType.WARNING);
         });
 
       const getTracingInfoPromise = this.promises
@@ -164,14 +189,12 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
           console.debug(
             `Error fetching Distributed Tracing plugin configuration. (Probably is not installed) ${error}`
           );
-          // For testing the distributed tracing integration locally, assign distributedTracingPluginConfig = "plugin manifest json"
         });
       const getNetobservPluginManifestPromise = this.promises
         .register('getNetobservPluginManifestPromise', getNetobservPluginManifest())
         .then(response => (netobservPluginConfig = response))
         .catch(error => {
           console.debug(`Failed to fetch Netobserv plugin configuration (plugin is not probably installed). ${error}`);
-          // For testing the netobserv integration locally, assign netobservPluginConfig = "plugin manifest json"
         });
       API.getStatus()
         .then(response => this.processServerStatus(response.data))
@@ -181,13 +204,11 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
 
       await Promise.all([
         getNamespacesPromise,
-        getServerConfigPromise,
         getTracingInfoPromise,
         getPluginPromise,
         getDistributedTracingPluginManifestPromise,
         getNetobservPluginManifestPromise
       ]).then(() => {
-        // Set kiosk data for OSSMC
         store.dispatch(
           GlobalActions.setKioskData({
             hasExternalTracing: !!distributedTracingPluginConfig,
@@ -198,6 +219,8 @@ class KialiControllerComponent extends React.Component<KialiControllerProps> {
     } catch (err) {
       console.error('Error loading kiali config', err);
     }
+
+    return true;
   };
 
   private applyUIDefaults = (): void => {

--- a/plugin/src/openshift/pages/IstiosPage.tsx
+++ b/plugin/src/openshift/pages/IstiosPage.tsx
@@ -14,53 +14,26 @@ import {
   K8sResourceCommon,
   ResourceLink,
   Timestamp,
-  useK8sWatchResources,
-  WatchK8sResources
+  useK8sWatchResource
 } from '@openshift-console/dynamic-plugin-sdk';
-import { istioResources, referenceFor } from '../utils/IstioResources';
 
 type IstioResource = K8sResourceCommon & {
-  _resourceId?: string;
+  spec?: { namespace?: string };
 };
 
-const watchConfig: WatchK8sResources<Record<string, K8sResourceCommon[]>> = {};
-for (const r of istioResources) {
-  watchConfig[r.id] = {
-    groupVersionKind: { group: r.group, version: r.version, kind: r.kind },
-    isList: true,
-    namespaced: true
-  };
-}
+const istioGVK = { group: 'sailoperator.io', version: 'v1', kind: 'Istio' };
 
 const IstiosPage: React.FC = () => {
-  const resources = useK8sWatchResources<Record<string, K8sResourceCommon[]>>(watchConfig);
+  const [resources, loaded, loadError] = useK8sWatchResource<IstioResource[]>({
+    groupVersionKind: istioGVK,
+    isList: true,
+    namespaced: false
+  });
 
-  const { allResources, loaded } = React.useMemo(() => {
-    const items: IstioResource[] = [];
-    let allDone = true;
-
-    for (const [id, result] of Object.entries(resources)) {
-      if (!result.loaded && !result.loadError) {
-        allDone = false;
-        continue;
-      }
-      if (result.loaded && !result.loadError && Array.isArray(result.data)) {
-        for (const item of result.data) {
-          items.push({ ...item, _resourceId: id });
-        }
-      }
-    }
-
-    items.sort((a, b) => {
-      const kindCmp = (a.kind ?? '').localeCompare(b.kind ?? '');
-      if (kindCmp !== 0) return kindCmp;
-      const nsCmp = (a.metadata?.namespace ?? '').localeCompare(b.metadata?.namespace ?? '');
-      if (nsCmp !== 0) return nsCmp;
-      return (a.metadata?.name ?? '').localeCompare(b.metadata?.name ?? '');
-    });
-
-    return { allResources: items, loaded: allDone };
-  }, [resources]);
+  const sorted = React.useMemo(() => {
+    if (!loaded || loadError || !Array.isArray(resources)) return [];
+    return [...resources].sort((a, b) => (a.metadata?.name ?? '').localeCompare(b.metadata?.name ?? ''));
+  }, [resources, loaded, loadError]);
 
   return (
     <>
@@ -72,7 +45,7 @@ const IstiosPage: React.FC = () => {
           <Bullseye>
             <Spinner size="xl" />
           </Bullseye>
-        ) : allResources.length === 0 ? (
+        ) : sorted.length === 0 ? (
           <EmptyState
             headingLevel="h2"
             icon={SearchIcon}
@@ -80,50 +53,38 @@ const IstiosPage: React.FC = () => {
             variant={EmptyStateVariant.lg}
           >
             <EmptyStateBody>
-              No Istio resources were found on this cluster. Istio CRDs may not be installed, or no resources have been
-              created yet.
+              No Istio resources were found on this cluster. The Sail Operator may not be installed, or no Istio
+              instances have been created yet.
             </EmptyStateBody>
           </EmptyState>
         ) : (
           <Table aria-label="Istio resources" variant="compact">
             <Thead>
               <Tr>
-                <Th>Kind</Th>
                 <Th>Name</Th>
                 <Th>Namespace</Th>
                 <Th>Created</Th>
               </Tr>
             </Thead>
             <Tbody>
-              {allResources.map(resource => {
-                const gvk = {
-                  group: resource.apiVersion?.includes('/') ? resource.apiVersion.split('/')[0] : '',
-                  version: resource.apiVersion?.includes('/') ? resource.apiVersion.split('/')[1] : resource.apiVersion ?? '',
-                  kind: resource.kind ?? ''
-                };
-                const ref = referenceFor(gvk);
-
-                return (
-                  <Tr key={`${ref}/${resource.metadata?.namespace}/${resource.metadata?.name}`}>
-                    <Td>{resource.kind}</Td>
-                    <Td>
-                      <ResourceLink
-                        groupVersionKind={gvk}
-                        name={resource.metadata?.name}
-                        namespace={resource.metadata?.namespace}
-                      />
-                    </Td>
-                    <Td>
-                      {resource.metadata?.namespace && (
-                        <ResourceLink kind="Namespace" name={resource.metadata.namespace} />
-                      )}
-                    </Td>
-                    <Td>
-                      <Timestamp timestamp={resource.metadata?.creationTimestamp ?? ''} />
-                    </Td>
-                  </Tr>
-                );
-              })}
+              {sorted.map(resource => (
+                <Tr key={resource.metadata?.name}>
+                  <Td>
+                    <ResourceLink
+                      groupVersionKind={istioGVK}
+                      name={resource.metadata?.name}
+                    />
+                  </Td>
+                  <Td>
+                    {resource.spec?.namespace && (
+                      <ResourceLink kind="Namespace" name={resource.spec.namespace} />
+                    )}
+                  </Td>
+                  <Td>
+                    <Timestamp timestamp={resource.metadata?.creationTimestamp ?? ''} />
+                  </Td>
+                </Tr>
+              ))}
             </Tbody>
           </Table>
         )}

--- a/plugin/src/openshift/pages/IstiosPage.tsx
+++ b/plugin/src/openshift/pages/IstiosPage.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Spinner,
+  Title
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { SearchIcon } from '@patternfly/react-icons';
+import {
+  K8sResourceCommon,
+  ResourceLink,
+  Timestamp,
+  useK8sWatchResources,
+  WatchK8sResources
+} from '@openshift-console/dynamic-plugin-sdk';
+import { istioResources, referenceFor } from '../utils/IstioResources';
+
+type IstioResource = K8sResourceCommon & {
+  _resourceId?: string;
+};
+
+const watchConfig: WatchK8sResources<Record<string, K8sResourceCommon[]>> = {};
+for (const r of istioResources) {
+  watchConfig[r.id] = {
+    groupVersionKind: { group: r.group, version: r.version, kind: r.kind },
+    isList: true,
+    namespaced: true
+  };
+}
+
+const IstiosPage: React.FC = () => {
+  const resources = useK8sWatchResources<Record<string, K8sResourceCommon[]>>(watchConfig);
+
+  const { allResources, loaded } = React.useMemo(() => {
+    const items: IstioResource[] = [];
+    let allDone = true;
+
+    for (const [id, result] of Object.entries(resources)) {
+      if (!result.loaded && !result.loadError) {
+        allDone = false;
+        continue;
+      }
+      if (result.loaded && !result.loadError && Array.isArray(result.data)) {
+        for (const item of result.data) {
+          items.push({ ...item, _resourceId: id });
+        }
+      }
+    }
+
+    items.sort((a, b) => {
+      const kindCmp = (a.kind ?? '').localeCompare(b.kind ?? '');
+      if (kindCmp !== 0) return kindCmp;
+      const nsCmp = (a.metadata?.namespace ?? '').localeCompare(b.metadata?.namespace ?? '');
+      if (nsCmp !== 0) return nsCmp;
+      return (a.metadata?.name ?? '').localeCompare(b.metadata?.name ?? '');
+    });
+
+    return { allResources: items, loaded: allDone };
+  }, [resources]);
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1">Istios</Title>
+      </PageSection>
+      <PageSection>
+        {!loaded ? (
+          <Bullseye>
+            <Spinner size="xl" />
+          </Bullseye>
+        ) : allResources.length === 0 ? (
+          <EmptyState
+            headingLevel="h2"
+            icon={SearchIcon}
+            titleText="No Istio resources found"
+            variant={EmptyStateVariant.lg}
+          >
+            <EmptyStateBody>
+              No Istio resources were found on this cluster. Istio CRDs may not be installed, or no resources have been
+              created yet.
+            </EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <Table aria-label="Istio resources" variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Kind</Th>
+                <Th>Name</Th>
+                <Th>Namespace</Th>
+                <Th>Created</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {allResources.map(resource => {
+                const gvk = {
+                  group: resource.apiVersion?.includes('/') ? resource.apiVersion.split('/')[0] : '',
+                  version: resource.apiVersion?.includes('/') ? resource.apiVersion.split('/')[1] : resource.apiVersion ?? '',
+                  kind: resource.kind ?? ''
+                };
+                const ref = referenceFor(gvk);
+
+                return (
+                  <Tr key={`${ref}/${resource.metadata?.namespace}/${resource.metadata?.name}`}>
+                    <Td>{resource.kind}</Td>
+                    <Td>
+                      <ResourceLink
+                        groupVersionKind={gvk}
+                        name={resource.metadata?.name}
+                        namespace={resource.metadata?.namespace}
+                      />
+                    </Td>
+                    <Td>
+                      {resource.metadata?.namespace && (
+                        <ResourceLink kind="Namespace" name={resource.metadata.namespace} />
+                      )}
+                    </Td>
+                    <Td>
+                      <Timestamp timestamp={resource.metadata?.creationTimestamp ?? ''} />
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </Tbody>
+          </Table>
+        )}
+      </PageSection>
+    </>
+  );
+};
+
+export default IstiosPage;

--- a/plugin/src/openshift/pages/KialisPage.tsx
+++ b/plugin/src/openshift/pages/KialisPage.tsx
@@ -1,0 +1,214 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertVariant,
+  Bullseye,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  PageSection,
+  Spinner,
+  Title
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { CheckCircleIcon, SearchIcon } from '@patternfly/react-icons';
+import {
+  K8sResourceCommon,
+  ResourceLink,
+  Timestamp,
+  consoleFetch,
+  useK8sWatchResource
+} from '@openshift-console/dynamic-plugin-sdk';
+
+const kialiGVK = { group: 'kiali.io', version: 'v1alpha1', kind: 'Kiali' };
+const CONSOLE_PLUGIN_URL = '/api/kubernetes/apis/console.openshift.io/v1/consoleplugins/ossmconsole';
+const PROXY_ALIAS = 'kiali';
+const KIALI_PORT = 20001;
+
+type ProxyEntry = {
+  alias: string;
+  endpoint: {
+    type: string;
+    service: { name: string; namespace: string; port: number };
+  };
+};
+
+type ConsolePluginResource = K8sResourceCommon & {
+  spec?: { proxy?: ProxyEntry[] };
+};
+
+const promoteToConsole = async (name: string, namespace: string): Promise<void> => {
+  const patch = {
+    spec: {
+      proxy: [
+        {
+          alias: PROXY_ALIAS,
+          endpoint: {
+            type: 'Service',
+            service: { name, namespace, port: KIALI_PORT }
+          },
+          authorization: 'UserToken'
+        }
+      ]
+    }
+  };
+
+  await consoleFetch(CONSOLE_PLUGIN_URL, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/merge-patch+json' },
+    body: JSON.stringify(patch)
+  });
+};
+
+const isPromoted = (plugin: ConsolePluginResource | null, name: string, namespace: string): boolean => {
+  const proxy = plugin?.spec?.proxy?.find(p => p.alias === PROXY_ALIAS);
+  if (!proxy) return false;
+  const svc = proxy.endpoint?.service;
+  return svc?.name === name && svc?.namespace === namespace;
+};
+
+const KialisPage: React.FC = () => {
+  const [resources, loaded, loadError] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: kialiGVK,
+    isList: true,
+    namespaced: true
+  });
+
+  const [plugin, setPlugin] = React.useState<ConsolePluginResource | null>(null);
+  const [promoting, setPromoting] = React.useState<string | null>(null);
+  const [alert, setAlert] = React.useState<{ variant: AlertVariant; message: string } | null>(null);
+
+  const fetchPlugin = React.useCallback(async () => {
+    try {
+      const response = await consoleFetch(CONSOLE_PLUGIN_URL);
+      const data = await response.json();
+      setPlugin(data);
+    } catch {
+      // ConsolePlugin not found — not critical
+    }
+  }, []);
+
+  React.useEffect(() => {
+    fetchPlugin();
+  }, [fetchPlugin]);
+
+  const sorted = React.useMemo(() => {
+    if (!loaded || loadError || !Array.isArray(resources)) return [];
+    return [...resources].sort((a, b) => (a.metadata?.name ?? '').localeCompare(b.metadata?.name ?? ''));
+  }, [resources, loaded, loadError]);
+
+  const crdMissing = loaded && !!loadError;
+
+  const handlePromote = async (name: string, namespace: string): Promise<void> => {
+    const key = `${namespace}/${name}`;
+    setPromoting(key);
+    setAlert(null);
+    try {
+      await promoteToConsole(name, namespace);
+      await fetchPlugin();
+      setAlert({ variant: AlertVariant.success, message: `Kiali "${name}" promoted to console. Refresh the page to activate.` });
+    } catch (err) {
+      setAlert({ variant: AlertVariant.danger, message: `Failed to promote: ${err instanceof Error ? err.message : String(err)}` });
+    } finally {
+      setPromoting(null);
+    }
+  };
+
+  return (
+    <>
+      <PageSection>
+        <Title headingLevel="h1">Kialis</Title>
+      </PageSection>
+      <PageSection>
+        {alert && (
+          <Alert variant={alert.variant} title={alert.message} isInline actionClose={<AlertActionCloseButton onClose={() => setAlert(null)} />} />
+        )}
+        {!loaded ? (
+          <Bullseye>
+            <Spinner size="xl" />
+          </Bullseye>
+        ) : crdMissing ? (
+          <EmptyState
+            headingLevel="h2"
+            icon={SearchIcon}
+            titleText="Kiali Operator is not installed"
+            variant={EmptyStateVariant.lg}
+          >
+            <EmptyStateBody>
+              The Kiali custom resource definition was not found on this cluster. Install the Kiali Operator from the{' '}
+              <a href="/catalog/ns/openshift-operators?keyword=kiali">OperatorHub</a> to manage Kiali instances.
+            </EmptyStateBody>
+          </EmptyState>
+        ) : sorted.length === 0 ? (
+          <EmptyState
+            headingLevel="h2"
+            icon={SearchIcon}
+            titleText="No Kiali resources found"
+            variant={EmptyStateVariant.lg}
+          >
+            <EmptyStateBody>
+              The Kiali Operator is installed but no Kiali instances have been created yet.
+            </EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <Table aria-label="Kiali resources" variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Name</Th>
+                <Th>Namespace</Th>
+                <Th>Created</Th>
+                <Th>Actions</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {sorted.map(resource => {
+                const name = resource.metadata?.name ?? '';
+                const namespace = resource.metadata?.namespace ?? '';
+                const key = `${namespace}/${name}`;
+                const promoted = isPromoted(plugin, name, namespace);
+
+                return (
+                  <Tr key={key}>
+                    <Td>
+                      <ResourceLink
+                        groupVersionKind={kialiGVK}
+                        name={name}
+                        namespace={namespace}
+                      />
+                    </Td>
+                    <Td>
+                      {namespace && <ResourceLink kind="Namespace" name={namespace} />}
+                    </Td>
+                    <Td>
+                      <Timestamp timestamp={resource.metadata?.creationTimestamp ?? ''} />
+                    </Td>
+                    <Td>
+                      {promoted ? (
+                        <Button variant="link" isDisabled icon={<CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />}>
+                          Promoted
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="secondary"
+                          isLoading={promoting === key}
+                          isDisabled={promoting !== null}
+                          onClick={() => handlePromote(name, namespace)}
+                        >
+                          Promote to Console
+                        </Button>
+                      )}
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </Tbody>
+          </Table>
+        )}
+      </PageSection>
+    </>
+  );
+};
+
+export default KialisPage;

--- a/plugin/src/openshift/utils/useKialiFlag.ts
+++ b/plugin/src/openshift/utils/useKialiFlag.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+const KIALI_REACHABLE = 'KIALI_REACHABLE';
+const KIALI_PROXY_URL = '/api/proxy/plugin/ossmconsole/kiali/api/config';
+
+export const useKialiFlag: (setFlag: (flag: string, enabled: boolean) => void) => void = setFlag => {
+  React.useEffect(() => {
+    consoleFetch(KIALI_PROXY_URL)
+      .then(response => setFlag(KIALI_REACHABLE, response.ok))
+      .catch(() => setFlag(KIALI_REACHABLE, false));
+  }, [setFlag]);
+};


### PR DESCRIPTION
### Describe the change

Allows you to run OSSMC independent of the Kiali backend. Adds an `Istios` page and a `Kialis` page that are always present when you install the `ConsolePlugin`. The other `Service Mesh` pages only appear once you hookup a Kiali to OSSMC.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
