### PR TITLE
[v2.22] Avoid PatternFly ToolbarFilter firstElementChild crash on Overview

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,16 @@ jobs:
       with:
         ref: ${{ inputs.build_branch }}
 
+    # ubuntu-latest ships a crun too old for OCI specs from current ubi9/nodejs-24
+    # (podman fails with "unknown version specified"). Keep podman; upgrade crun only.
+    - name: Upgrade crun for podman
+      run: |
+        CRUN_VERSION=1.21
+        curl -fsSL -o /tmp/crun "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-amd64"
+        sudo install -m 755 /tmp/crun /usr/local/bin/crun
+        sudo ln -sfn /usr/local/bin/crun /usr/bin/crun
+        crun --version
+
     - name: Build image
       run: |
         make -e CONTAINER_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile) build-plugin-image

--- a/plugin/src/kiali/components/Filters/StatefulFilters.tsx
+++ b/plugin/src/kiali/components/Filters/StatefulFilters.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import {
+  Button,
   Checkbox,
+  Label,
+  LabelGroup,
   TextInput,
   TextInputTypes,
   Toolbar,
@@ -635,49 +638,34 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
         <Toolbar
           id="filter-selection"
           className={this.props.toolbarClass ? classes(toolbarStyle, this.props.toolbarClass) : toolbarStyle}
-          clearAllFilters={this.clearFilters}
         >
           {this.props.childrenFirst && this.renderChildren()}
           <ToolbarContent>
             <ToolbarGroup variant="filter-group">
-              {this.state.filterTypes.map((ft, i) => (
-                <ToolbarFilter
-                  key={`toolbar_filter-${ft.category}`}
-                  labels={activeFilters.filters
-                    .filter(af => af.category === ft.category)
-                    .map(af => ({
-                      key: af.value,
-                      node: t(af.value)
-                    }))}
-                  deleteLabel={this.removeFilter}
-                  categoryName={{ key: ft.category, name: t(ft.category) }}
+              <ToolbarFilter categoryName="">
+                <Select
+                  id="filter_select_type"
+                  onSelect={(_event, value) => this.selectFilterType(value as string)}
+                  onOpenChange={isFilterTypeOpen => this.setState({ isFilterTypeOpen })}
+                  toggle={filterTypeToggle}
+                  isOpen={this.state.isFilterTypeOpen}
+                  aria-label="Filter Select Type"
                 >
-                  {i === 0 && (
-                    <Select
-                      id="filter_select_type"
-                      onSelect={(_event, value) => this.selectFilterType(value as string)}
-                      onOpenChange={isFilterTypeOpen => this.setState({ isFilterTypeOpen })}
-                      toggle={filterTypeToggle}
-                      isOpen={this.state.isFilterTypeOpen}
-                      aria-label="Filter Select Type"
-                    >
-                      <SelectList>
-                        {this.state.filterTypes.map(option => (
-                          <SelectOption
-                            id={option.category}
-                            key={option.category}
-                            value={option.category}
-                            isSelected={option.category === currentFilterType.category}
-                          >
-                            {t(option.category)}
-                          </SelectOption>
-                        ))}
-                      </SelectList>
-                    </Select>
-                  )}
-                  {i === 0 && this.renderInput()}
-                </ToolbarFilter>
-              ))}
+                  <SelectList>
+                    {this.state.filterTypes.map(option => (
+                      <SelectOption
+                        id={option.category}
+                        key={option.category}
+                        value={option.category}
+                        isSelected={option.category === currentFilterType.category}
+                      >
+                        {t(option.category)}
+                      </SelectOption>
+                    ))}
+                  </SelectList>
+                </Select>
+                {this.renderInput()}
+              </ToolbarFilter>
             </ToolbarGroup>
 
             <ToolbarGroup>
@@ -696,8 +684,6 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
                   </ToolbarItem>
                 ))}
             </ToolbarGroup>
-
-            {!this.props.childrenFirst && this.renderChildren()}
 
             {hasActiveFilters && (
               <ToolbarGroup>
@@ -739,7 +725,46 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
                 </ToolbarItem>
               </ToolbarGroup>
             )}
+
+            {!this.props.childrenFirst && this.renderChildren()}
           </ToolbarContent>
+
+          {activeFilters.filters.length > 0 && (
+            <ToolbarContent>
+              <ToolbarGroup>
+                <ToolbarItem>
+                  {this.state.filterTypes.map(ft => {
+                    const filtersForCategory = activeFilters.filters.filter(af => af.category === ft.category);
+                    if (filtersForCategory.length === 0) {
+                      return null;
+                    }
+                    return (
+                      <LabelGroup
+                        key={ft.category}
+                        categoryName={t(ft.category)}
+                        style={{ marginRight: 'var(--pf-t--global--spacer--md)' }}
+                      >
+                        {filtersForCategory.map(af => (
+                          <Label
+                            key={af.value}
+                            onClose={() => this.removeFilter(ft.category, af.value)}
+                            closeBtnProps={{ 'aria-label': `Close ${af.value}` }}
+                          >
+                            {t(af.value)}
+                          </Label>
+                        ))}
+                      </LabelGroup>
+                    );
+                  })}
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button variant="link" onClick={this.clearFilters}>
+                    {t('Clear all filters')}
+                  </Button>
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarContent>
+          )}
         </Toolbar>
         <div className={bottomPadding} />
       </>

--- a/plugin/src/kiali/components/Filters/StatefulFilters.tsx
+++ b/plugin/src/kiali/components/Filters/StatefulFilters.tsx
@@ -10,7 +10,6 @@ import {
   ToolbarGroup,
   ToolbarItem,
   ToolbarContent,
-  ToolbarFilter,
   Select,
   SelectList,
   SelectOption,
@@ -642,7 +641,7 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
           {this.props.childrenFirst && this.renderChildren()}
           <ToolbarContent>
             <ToolbarGroup variant="filter-group">
-              <ToolbarFilter categoryName="">
+              <ToolbarItem>
                 <Select
                   id="filter_select_type"
                   onSelect={(_event, value) => this.selectFilterType(value as string)}
@@ -664,8 +663,8 @@ export class StatefulFiltersComponent extends React.Component<StatefulFiltersPro
                     ))}
                   </SelectList>
                 </Select>
-                {this.renderInput()}
-              </ToolbarFilter>
+              </ToolbarItem>
+              <ToolbarItem>{this.renderInput()}</ToolbarItem>
             </ToolbarGroup>
 
             <ToolbarGroup>


### PR DESCRIPTION
### Describe the change

[v2.22] Avoid PatternFly ToolbarFilter firstElementChild crash on Overview 
Render filter chips with LabelGroup instead of ToolbarFilter labels so OSSMC does not hit the PF 6.4 null portal bug shared by OCP 4.22 Console.

This only fails on the v2.22 branch because it still uses the older StatefulFilters pattern with multiple PatternFly ToolbarFilter components and portal-based labels, which hits a known PF 6.4 null firstElementChild crash shared by the OCP 4.22 Console. Newer branches (v2.24+) already ship the Kiali frontend rewrite that renders filter chips with LabelGroup instead, so they avoid that broken portal path; that change was never backported to v2.22.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
