### PR TITLE
fix: load monaco-editor locally instead of from cdn.jsdelivr.net

### DIFF
--- a/plugin/src/openshift/components/KialiContainer.tsx
+++ b/plugin/src/openshift/components/KialiContainer.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
+import { classes } from 'typestyle';
+
 import { store } from 'store/ConfigStore';
+import { globalStyle as kialiStyle } from 'styles/GlobalStyle';
+import kialiCSSVariables from 'styles/variables.module.scss';
+
 import { KialiController } from '../components/KialiController';
 import { NotificationAlerts } from '../components/NotificationAlerts';
-import { globalStyle as kialiStyle } from 'styles/GlobalStyle';
 import { globalStyle as ossmcStyle } from '../styles/GlobalStyle';
-import kialiCSSVariables from 'styles/variables.module.scss';
 import ossmcCSSVariables from '../styles/variables.module.scss';
 
-// Load the pf-icons
 import '@patternfly/patternfly/patternfly-base.css';
-
-import { classes } from 'typestyle';
+// Load the pf-icons
 
 // Configure @monaco-editor/react to use the locally bundled monaco-editor before any page
 // can render an editor. See MonacoSetup.ts for details.

--- a/plugin/src/openshift/components/KialiContainer.tsx
+++ b/plugin/src/openshift/components/KialiContainer.tsx
@@ -13,6 +13,10 @@ import '@patternfly/patternfly/patternfly-base.css';
 
 import { classes } from 'typestyle';
 
+// Configure @monaco-editor/react to use the locally bundled monaco-editor before any page
+// can render an editor. See MonacoSetup.ts for details.
+import '../utils/MonacoSetup';
+
 interface Props {
   children: React.ReactNode;
   className?: string;

--- a/plugin/src/openshift/components/KialiContainer.tsx
+++ b/plugin/src/openshift/components/KialiContainer.tsx
@@ -11,8 +11,8 @@ import { NotificationAlerts } from '../components/NotificationAlerts';
 import { globalStyle as ossmcStyle } from '../styles/GlobalStyle';
 import ossmcCSSVariables from '../styles/variables.module.scss';
 
-import '@patternfly/patternfly/patternfly-base.css';
 // Load the pf-icons
+import '@patternfly/patternfly/patternfly-base.css';
 
 // Configure @monaco-editor/react to use the locally bundled monaco-editor before any page
 // can render an editor. See MonacoSetup.ts for details.

--- a/plugin/src/openshift/utils/MonacoSetup.ts
+++ b/plugin/src/openshift/utils/MonacoSetup.ts
@@ -13,10 +13,9 @@ loader.config({ monaco });
 // resource editor and, via monaco-editor-webpack-plugin's `globalAPI: true` option, sets a
 // page-wide `window.MonacoEnvironment.getWorkerUrl`. Since our plugin runs in the same browser
 // realm as Console, our editor instances would otherwise inherit Console's worker URL and speak
-// an incompatible RPC protocol to a differently versioned worker script, surfacing as
-// "Uncaught TypeError: e is not iterable" the first time a lazily-created worker is needed
-// (e.g. link detection or word-based suggestions). Providing our own getWorker keeps OSSMC's
-// Monaco instance self-contained regardless of what Console has set on the shared global.
+// an incompatible RPC protocol to a differently versioned worker script. Providing our own
+// getWorker keeps OSSMC's Monaco instance self-contained regardless of what Console has set on
+// the shared global.
 self.MonacoEnvironment = {
   getWorker: () =>
     new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker.js', import.meta.url), { type: 'module' })

--- a/plugin/src/openshift/utils/MonacoSetup.ts
+++ b/plugin/src/openshift/utils/MonacoSetup.ts
@@ -2,10 +2,22 @@ import * as monaco from 'monaco-editor';
 import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';
 import { loader } from '@monaco-editor/react';
 
-// webpack.config.ts aliases 'monaco-editor' to the worker-free editor.api entry point, which
-// keeps Monaco's web worker scripts out of the bundle. Without this, @monaco-editor/react
-// fetches those worker scripts from cdn.jsdelivr.net at runtime, breaking the YAML editor in
-// air-gapped/disconnected clusters and causing flaky Cypress failures when the CDN is
-// unreachable. editor.api excludes basic-language contributions, so the YAML Monarch
+// webpack.config.ts aliases 'monaco-editor' to editor.api.js so @monaco-editor/react loads the
+// bundled monaco-editor instead of fetching it from cdn.jsdelivr.net at runtime. Without this,
+// the YAML editor breaks in air-gapped/disconnected clusters and Cypress is flaky whenever the
+// CDN is unreachable. editor.api ships without any basic-language grammar, so the YAML Monarch
 // tokenizer is imported explicitly above to keep syntax highlighting working.
 loader.config({ monaco });
+
+// OpenShift Console bundles its own, separately versioned monaco-editor for its "Edit YAML"
+// resource editor and, via monaco-editor-webpack-plugin's `globalAPI: true` option, sets a
+// page-wide `window.MonacoEnvironment.getWorkerUrl`. Since our plugin runs in the same browser
+// realm as Console, our editor instances would otherwise inherit Console's worker URL and speak
+// an incompatible RPC protocol to a differently versioned worker script, surfacing as
+// "Uncaught TypeError: e is not iterable" the first time a lazily-created worker is needed
+// (e.g. link detection or word-based suggestions). Providing our own getWorker keeps OSSMC's
+// Monaco instance self-contained regardless of what Console has set on the shared global.
+self.MonacoEnvironment = {
+  getWorker: () =>
+    new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker.js', import.meta.url), { type: 'module' })
+};

--- a/plugin/src/openshift/utils/MonacoSetup.ts
+++ b/plugin/src/openshift/utils/MonacoSetup.ts
@@ -1,0 +1,11 @@
+import * as monaco from 'monaco-editor';
+import 'monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution';
+import { loader } from '@monaco-editor/react';
+
+// webpack.config.ts aliases 'monaco-editor' to the worker-free editor.api entry point, which
+// keeps Monaco's web worker scripts out of the bundle. Without this, @monaco-editor/react
+// fetches those worker scripts from cdn.jsdelivr.net at runtime, breaking the YAML editor in
+// air-gapped/disconnected clusters and causing flaky Cypress failures when the CDN is
+// unreachable. editor.api excludes basic-language contributions, so the YAML Monarch
+// tokenizer is imported explicitly above to keep syntax highlighting working.
+loader.config({ monaco });

--- a/plugin/webpack.config.ts
+++ b/plugin/webpack.config.ts
@@ -37,6 +37,12 @@ const config: Configuration = {
     assetModuleFilename: 'static/media/[name].[hash][ext]'
   },
   resolve: {
+    alias: {
+      // Redirect to the worker-free editor.api entry point so @monaco-editor/react uses the
+      // bundled monaco-editor instead of fetching worker scripts from cdn.jsdelivr.net at
+      // runtime. See src/openshift/utils/MonacoSetup.ts for the matching loader configuration.
+      'monaco-editor$': path.resolve(__dirname, 'node_modules/monaco-editor/esm/vs/editor/editor.api.js')
+    },
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
     plugins: [new TsconfigPathsPlugin()]
   },

--- a/plugin/webpack.config.ts
+++ b/plugin/webpack.config.ts
@@ -38,9 +38,9 @@ const config: Configuration = {
   },
   resolve: {
     alias: {
-      // Redirect to the worker-free editor.api entry point so @monaco-editor/react uses the
-      // bundled monaco-editor instead of fetching worker scripts from cdn.jsdelivr.net at
-      // runtime. See src/openshift/utils/MonacoSetup.ts for the matching loader configuration.
+      // Redirect to the editor.api entry point so @monaco-editor/react uses the bundled
+      // monaco-editor instead of fetching it from cdn.jsdelivr.net at runtime. See
+      // src/openshift/utils/MonacoSetup.ts for the matching loader/worker configuration.
       'monaco-editor$': path.resolve(__dirname, 'node_modules/monaco-editor/esm/vs/editor/editor.api.js')
     },
     extensions: ['.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
## Summary

- Alias `monaco-editor` to the `editor.api` entry point in `webpack.config.ts`, so `@monaco-editor/react` loads the locally bundled `monaco-editor` instead of fetching it from `cdn.jsdelivr.net` at runtime.
- Add `src/openshift/utils/MonacoSetup.ts`, which configures `@monaco-editor/react`'s loader via `loader.config({ monaco })`, explicitly imports the YAML basic-language contribution (excluded by `editor.api`), and sets a self-contained `MonacoEnvironment.getWorker` so OSSMC's Monaco instance does not inherit OpenShift Console's global worker configuration.
- Import `MonacoSetup` from `KialiContainer`, which every OSSMC page renders through, ensuring the loader and worker setup run before any page can mount a Monaco editor.

## Problem

`@monaco-editor/react` (v4.7.0) defaults to fetching Monaco from `cdn.jsdelivr.net` at runtime, even though `monaco-editor` (v0.55.1) is already installed as a local dependency. This causes:

1. **Air-gapped / disconnected OpenShift environments**: Users behind firewalls or in disconnected clusters can't use the YAML editor at all since it requires live HTTP access to `cdn.jsdelivr.net`.
2. **Potential CI test flakes**: Cypress tests that navigate to pages with Monaco editors could fail when `cdn.jsdelivr.net` is slow or unreachable.
3. **Unnecessary network dependency**: Every page load with an editor component makes external HTTP requests for a library that's already bundled in `node_modules`.

Additionally, once Monaco is loaded locally, OSSMC still shares the browser realm with OpenShift Console. Console bundles its own, separately versioned `monaco-editor` and (via `monaco-editor-webpack-plugin`'s `globalAPI: true`) sets a page-wide `window.MonacoEnvironment.getWorkerUrl`. Without our own `getWorker`, OSSMC editor instances would inherit Console's worker URL and speak an incompatible RPC protocol to a differently versioned worker script.

This mirrors [kiali/kiali#10131](https://github.com/kiali/kiali/pull/10131), which fixed the CDN issue in the Kiali standalone frontend (`rsbuild.config.ts` + `index.tsx`). OSSMC needs its own equivalent fix since it uses a different build (webpack, not Rsbuild) and has no traditional entry point — pages are lazily loaded via `console-extensions.ts` `$codeRef`s, so `KialiContainer` (rendered by every OSSMC page) is used as the initialization point instead. The Console `MonacoEnvironment` collision is OSSMC-specific and has no standalone-Kiali counterpart.

## Test plan

- [x] `yarn build` completes successfully with the alias in place
- [x] `yarn lint` passes with no new errors
- [x] `tsc --noEmit` passes with no errors
- [x] `yarn test src/openshift` passes
- [x] Verified the production bundle no longer emits the full `editor.main` worker bundle graph for the aliased `monaco-editor` import
- [x] Local OSSMC: YAML editor opens without CDN requests and without inheriting Console's Monaco worker

Fixes #790

Made with [Cursor](https://cursor.com)