### PR TITLE
Fix several UI/navigation bugs found in Kiali frontend

### DIFF
--- a/plugin/src/kiali/components/Nav/Navigation.tsx
+++ b/plugin/src/kiali/components/Nav/Navigation.tsx
@@ -72,6 +72,24 @@ export const NavigationComponent: React.FC<NavigationProps> = (props: Navigation
     document.title = pageTitle;
   }, []);
 
+  // Keep page content aligned when the notification drawer is collapsed. Focus or
+  // automation can scroll drawer__main horizontally into the reserved panel slot.
+  React.useEffect(() => {
+    if (props.showNotificationCenter) {
+      return;
+    }
+
+    const resetDrawerScroll = (): void => {
+      document.querySelectorAll('.pf-v6-c-drawer__main').forEach(el => {
+        (el as HTMLElement).scrollLeft = 0;
+      });
+    };
+
+    resetDrawerScroll();
+    const id = requestAnimationFrame(resetDrawerScroll);
+    return () => cancelAnimationFrame(id);
+  }, [props.showNotificationCenter, pathname]);
+
   const isGraph = (): boolean => {
     return pathname.startsWith('/graph') || pathname.startsWith('/mesh');
   };

--- a/plugin/src/kiali/components/Table/SimpleTable.tsx
+++ b/plugin/src/kiali/components/Table/SimpleTable.tsx
@@ -119,11 +119,22 @@ export const SimpleTable: React.FC<SimpleTableProps> = (props: SimpleTableProps)
         {props.rows.length > 0 ? (
           props.rows.map((row, rowIndex) => (
             <Tr key={row.key ?? `row_${rowIndex}`} className={row.className}>
-              {row.cells?.map((cell: React.ReactNode, colIndex: number) => (
-                <Td key={`cell_${rowIndex}_${colIndex}`} dataLabel={props.columns[colIndex].title} className={tdStyle}>
-                  {cell}
-                </Td>
-              ))}
+              {row.cells?.map((cell, colIndex: number) => {
+                const cellContent =
+                  typeof cell === 'object' && cell !== null && 'title' in cell
+                    ? (cell as { title: React.ReactNode }).title
+                    : (cell as React.ReactNode);
+
+                return (
+                  <Td
+                    key={`cell_${rowIndex}_${colIndex}`}
+                    dataLabel={props.columns[colIndex].title}
+                    className={tdStyle}
+                  >
+                    {cellContent}
+                  </Td>
+                );
+              })}
 
               {getActionToggle(row, rowIndex)}
             </Tr>

--- a/plugin/src/kiali/pages/Graph/GraphHelpTour.tsx
+++ b/plugin/src/kiali/pages/Graph/GraphHelpTour.tsx
@@ -65,7 +65,7 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   },
   Shortcuts: {
     name: t('Shortcuts'),
-    htmlDescription: GraphShortcuts,
+    htmlDescription: GraphShortcuts(),
     position: PopoverPosition.leftStart
   },
   SidePanel: {

--- a/plugin/src/kiali/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/plugin/src/kiali/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -192,17 +192,21 @@ class GraphToolbarComponent extends React.PureComponent<GraphToolbarProps> {
   }
 
   render(): React.ReactNode {
+    // Prefer URL over Redux for first paint: setNode runs in GraphPage.componentDidMount,
+    // so Redux can lag one frame behind a node-graph route.
+    const isNodeGraph = !!this.props.node || location.getPathname().includes('/graph/node');
+
     return (
       <>
         <GraphSecondaryMasthead
           disabled={this.props.disabled}
           graphType={this.props.graphType}
-          isNodeGraph={!!this.props.node}
+          isNodeGraph={isNodeGraph}
           onGraphTypeChange={this.props.setGraphType}
         />
         <Toolbar style={{ paddingTop: '1rem', width: '100%' }}>
           <ToolbarGroup aria-label="graph settings" style={{ margin: 0, alignItems: 'flex-start' }}>
-            {this.props.node && (
+            {isNodeGraph && (
               <ToolbarItem style={{ margin: 0 }}>
                 <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content={t('Back to full graph')}>
                   <Button variant={ButtonVariant.link} onClick={this.handleNamespaceReturn}>

--- a/plugin/src/kiali/pages/Graph/MiniGraphCard.tsx
+++ b/plugin/src/kiali/pages/Graph/MiniGraphCard.tsx
@@ -364,7 +364,7 @@ class MiniGraphCardComponent extends React.Component<MiniGraphCardProps, MiniGra
         }
       }
 
-      router.navigate(`${location.getPathname()}?&{urlParams.toString()}`, { replace: true });
+      router.navigate(`${location.getPathname()}?${urlParams.toString()}`, { replace: true });
     }
   };
 

--- a/plugin/src/kiali/pages/Graph/styles/styleGroup.tsx
+++ b/plugin/src/kiali/pages/Graph/styles/styleGroup.tsx
@@ -108,16 +108,17 @@ const StyleGroupComponent: React.FC<StyleGroupProps> = ({
 
   const boxRef = React.useRef<Rect | null>(null);
   boxRef.current = element.getBounds();
+  const boxBounds = boxRef.current;
 
   return (
     <g style={{ opacity: opacity }} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
-      {data.isFocus && (
+      {data.isFocus && boxBounds && (
         <rect
           className={focusOverlayStyle}
-          x={boxRef.current.x}
-          y={boxRef.current.y}
-          width={boxRef.current.width}
-          height={boxRef.current.height}
+          x={boxBounds.x}
+          y={boxBounds.y}
+          width={boxBounds.width}
+          height={boxBounds.height}
         />
       )}
       <DefaultGroup

--- a/plugin/src/kiali/pages/Mesh/MeshHelpTour.tsx
+++ b/plugin/src/kiali/pages/Mesh/MeshHelpTour.tsx
@@ -42,7 +42,7 @@ export const MeshTourStops: { [name: string]: TourStopInfo } = {
   },
   Shortcuts: {
     name: t('Shortcuts'),
-    htmlDescription: MeshShortcuts,
+    htmlDescription: MeshShortcuts(),
     position: PopoverPosition.leftStart
   },
   TargetPanel: {

--- a/plugin/src/kiali/pages/Overview/DataPlaneStats.tsx
+++ b/plugin/src/kiali/pages/Overview/DataPlaneStats.tsx
@@ -159,6 +159,9 @@ export const DataPlaneStats: React.FC = () => {
   const unhealthyCount = failureCount + degradedCount + notReadyCount;
   const isCardLoading = isNamespacesLoading || isHealthLoading;
   const isCardError = isNamespacesError || isError;
+  // Keep the footer during health-only refreshes so the link is not detached mid-click.
+  // Hide only while namespaces are still loading or the card is in error.
+  const showFooter = !isCardError && !isNamespacesLoading && (total > 0 || !isHealthLoading);
 
   const unhealthyNamespaces: NamespaceWithHealthStatus[] = React.useMemo(() => {
     const severity = (s: HealthStatusId): number => {
@@ -287,7 +290,7 @@ export const DataPlaneStats: React.FC = () => {
           </div>
         )}
       </CardBody>
-      {!isCardLoading && !isCardError && (
+      {showFooter && (
         <CardFooter>
           <KialiLink
             to={buildDataPlanesUrl()}

--- a/plugin/src/kiali/styles/GlobalStyle.ts
+++ b/plugin/src/kiali/styles/GlobalStyle.ts
@@ -45,6 +45,28 @@ export const globalStyle = kialiStyle({
     },
 
     /**
+     * Collapse the closed notification drawer panel so it cannot steal horizontal
+     * scroll. PatternFly reserves FlexBasis (e.g. 28.125rem) for the panel while
+     * collapsed; focus/automation can set scrollLeft on drawer__main and shift the
+     * page content under the sidebar, clipping toolbar controls and table headers.
+     */
+    '& .pf-v6-c-drawer:not(.pf-m-expanded) > .pf-v6-c-drawer__main > .pf-v6-c-drawer__panel': {
+      flexBasis: '0 !important',
+      margin: '0 !important',
+      maxWidth: '0 !important',
+      minWidth: '0 !important',
+      overflow: 'hidden',
+      padding: '0 !important',
+      transform: 'none !important',
+      visibility: 'hidden',
+      width: '0 !important'
+    },
+
+    '& .pf-v6-c-drawer__main': {
+      overflowX: 'hidden'
+    },
+
+    /**
      * Reduce padding of menu group title
      */
     '& .pf-v6-c-menu__group-title': {


### PR DESCRIPTION
Fixes a handful of small, unrelated bugs found while working on other changes elsewhere in the codebase:

- MiniGraphCard: fixed a query-string typo that produced a literal `?&{urlParams...}` in the URL instead of interpolating the params.
- SimpleTable: cells shaped as `{ title }` objects now render their title instead of `[object Object]`.
- DataPlaneStats: the "view data planes" footer link now stays visible during health-only refreshes instead of disappearing mid-click.
- Navigation/GlobalStyle: the collapsed notification drawer no longer steals horizontal scroll and clips toolbar/table content.
- GraphHelpTour/MeshHelpTour: the Shortcuts tour stop now renders the shortcuts content instead of a stray function reference.
- GraphToolbar: the node-graph toolbar no longer briefly renders as the full graph on first paint, by preferring the URL over Redux state.
- styleGroup: added a null check to avoid a possible crash when a group node's bounds aren't yet available.

fixes: https://github.com/kiali/kiali/issues/10151

Generated-by: Cursor